### PR TITLE
Respecting source media info resolution attributes

### DIFF
--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -146,7 +146,6 @@ class FlameAppFramework(object):
 
         self.log.info("[{}] waking up".format(self.__class__.__name__))
 
-        
         try:
             self.load_prefs()
         except RuntimeError:
@@ -820,6 +819,25 @@ class MediaInfoFile(object):
 
             self.clip_data = xml_data
 
+    def _get_typed_value(self, xml_obj):
+        """ Get typed value from xml object
+
+        Args:
+            xml_obj (xml.etree.ElementTree.Element): xml object
+
+        Returns:
+            str: value
+        """
+        if hasattr(xml_obj, "type"):
+            if xml_obj.type in ["int", "uint"]:
+                return int(xml_obj.text)
+            if xml_obj.type == "float":
+                return float(xml_obj.text)
+            if xml_obj.type == "string":
+                return str(xml_obj.text)
+
+        return xml_obj.text
+
     def _get_collection(self, feed_basename, feed_dir, feed_ext):
         """ Get collection string
 
@@ -1100,17 +1118,19 @@ class MediaInfoFile(object):
                     # start frame
                     out_feed_nb_ticks_obj = out_feed.find(
                         "startTimecode/nbTicks")
-                    self.start_frame = out_feed_nb_ticks_obj.text
+                    self.start_frame = self._get_typed_value(
+                        out_feed_nb_ticks_obj)
 
                     # fps
                     out_feed_fps_obj = out_feed.find(
                         "startTimecode/rate")
-                    self.fps = out_feed_fps_obj.text
+                    self.fps = self._get_typed_value(out_feed_fps_obj)
 
                     # drop frame mode
                     out_feed_drop_mode_obj = out_feed.find(
                         "startTimecode/dropMode")
-                    self.drop_mode = out_feed_drop_mode_obj.text
+                    self.drop_mode = self._get_typed_value(
+                        out_feed_drop_mode_obj)
                     break
         except Exception as msg:
             self.log.warning(msg)
@@ -1126,16 +1146,17 @@ class MediaInfoFile(object):
                 for out_feed in out_track.iter("feed"):
                     # width
                     out_feed_width_obj = out_feed.find("storageFormat/width")
-                    self.width = out_feed_width_obj.text
+                    self.width = self._get_typed_value(out_feed_width_obj)
 
                     # height
                     out_feed_height_obj = out_feed.find("storageFormat/height")
-                    self.height = out_feed_height_obj.text
+                    self.height = self._get_typed_value(out_feed_height_obj)
 
                     # pixel aspect ratio
                     out_feed_pixel_aspect_obj = out_feed.find(
                         "storageFormat/pixelRatio")
-                    self.pixel_aspect = out_feed_pixel_aspect_obj.text
+                    self.pixel_aspect = self._get_typed_value(
+                        out_feed_pixel_aspect_obj)
                     break
         except Exception as msg:
             self.log.warning(msg)

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -812,6 +812,12 @@ class MediaInfoFile(object):
             self.log.debug("start_frame: {}".format(self.start_frame))
             self.log.debug("fps: {}".format(self.fps))
             self.log.debug("drop frame: {}".format(self.drop_mode))
+            # get all resolution related data and assign them
+            self._get_resolution_info_from_origin(xml_data)
+            self.log.debug("width: {}".format(self.width))
+            self.log.debug("height: {}".format(self.height))
+            self.log.debug("pixel aspect: {}".format(self.pixel_aspect))
+
             self.clip_data = xml_data
 
     def _get_collection(self, feed_basename, feed_dir, feed_ext):
@@ -1105,6 +1111,31 @@ class MediaInfoFile(object):
                     out_feed_drop_mode_obj = out_feed.find(
                         "startTimecode/dropMode")
                     self.drop_mode = out_feed_drop_mode_obj.text
+                    break
+        except Exception as msg:
+            self.log.warning(msg)
+
+    def _get_resolution_info_from_origin(self, xml_data):
+        """Set resolution info to class attributes
+
+        Args:
+            xml_data (ET.Element): clip data
+        """
+        try:
+            for out_track in xml_data.iter("track"):
+                for out_feed in out_track.iter("feed"):
+                    # width
+                    out_feed_width_obj = out_feed.find("storageFormat/width")
+                    self.width = out_feed_width_obj.text
+
+                    # height
+                    out_feed_height_obj = out_feed.find("storageFormat/height")
+                    self.height = out_feed_height_obj.text
+
+                    # pixel aspect ratio
+                    out_feed_pixel_aspect_obj = out_feed.find(
+                        "storageFormat/pixelRatio")
+                    self.pixel_aspect = out_feed_pixel_aspect_obj.text
                     break
         except Exception as msg:
             self.log.warning(msg)

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -205,8 +205,16 @@ def create_otio_markers(otio_item, item):
         otio_item.markers.append(otio_marker)
 
 
-def create_otio_reference(clip_data, fps=None):
+def create_otio_reference(clip_data, media_info, fps=None):
     metadata = _get_metadata(clip_data)
+
+    metadata.update(
+        {
+            "ayon.source.width": media_info.width,
+            "ayon.source.height": media_info.height,
+            "ayon.source.pixelAspect": media_info.pixel_aspect,
+        }
+    )
     duration = int(clip_data["source_duration"])
 
     # get file info for path and start frame
@@ -346,8 +354,7 @@ def create_otio_clip(clip_data):
     log.debug("_ _clip_record_duration: {}".format(_clip_record_duration))
 
     # create media reference
-    media_reference = create_otio_reference(
-        clip_data, media_fps)
+    media_reference = create_otio_reference(clip_data, media_info, media_fps)
 
     # creatae source range
     source_range = create_otio_time_range(


### PR DESCRIPTION
## Changes
Flame is now supporting Source resolution inheritance for targeting workfile resolution.

## Testing steps
1. create clip on timeline with Source resolution enabled toggle
2. open publisher and publish the clip
3. all should work as expected and no fail should be monitored during publishing.