### PR TITLE
Fixing multiple `:` split issue and others small issues

### DIFF
--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -538,10 +538,10 @@ def get_segment_attributes(segment):
         "shot_name": segment.shot_name.get_value(),
         "segment_name": segment.name.get_value(),
         "segment_comment": segment.comment.get_value(),
-        "tape_name": segment.tape_name,
-        "source_name": segment.source_name,
-        "fpath": segment.file_path,
-        "PySegment": segment
+        "tape_name": segment.tape_name.get_value(),
+        "source_name": segment.source_name.get_value(),
+        "fpath": segment.file_path.get_value(),
+        "PySegment": segment,
     }
 
     # head and tail with forward compatibility

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -1154,17 +1154,17 @@ class MediaInfoFile(object):
                 for out_feed in out_track.iter("feed"):
                     # width
                     out_feed_width_obj = out_feed.find("storageFormat/width")
-                    self.width = self._get_typed_value(out_feed_width_obj)
+                    self.width = int(self._get_typed_value(out_feed_width_obj))
 
                     # height
                     out_feed_height_obj = out_feed.find("storageFormat/height")
-                    self.height = self._get_typed_value(out_feed_height_obj)
+                    self.height = int(self._get_typed_value(out_feed_height_obj))
 
                     # pixel aspect ratio
                     out_feed_pixel_aspect_obj = out_feed.find(
                         "storageFormat/pixelRatio")
-                    self.pixel_aspect = self._get_typed_value(
-                        out_feed_pixel_aspect_obj)
+                    self.pixel_aspect = float(
+                        self._get_typed_value(out_feed_pixel_aspect_obj))
                     break
         except Exception as msg:
             self.log.warning(msg)

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -539,8 +539,8 @@ def get_segment_attributes(segment):
         "segment_name": segment.name.get_value(),
         "segment_comment": segment.comment.get_value(),
         "tape_name": segment.tape_name,
-        "source_name": segment.source_name.get_value(),
-        "fpath": segment.file_path.get_value(),
+        "source_name": segment.source_name,
+        "fpath": segment.file_path,
         "PySegment": segment,
     }
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -538,7 +538,7 @@ def get_segment_attributes(segment):
         "shot_name": segment.shot_name.get_value(),
         "segment_name": segment.name.get_value(),
         "segment_comment": segment.comment.get_value(),
-        "tape_name": segment.tape_name.get_value(),
+        "tape_name": segment.tape_name,
         "source_name": segment.source_name.get_value(),
         "fpath": segment.file_path.get_value(),
         "PySegment": segment,

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -643,36 +643,27 @@ class PublishableClip:
                     self.log.debug(
                         f">> clip_product_name: {clip_product_name}")
 
+                    # in case track name and product name is the same then add
+                    if self.base_product_name == self.track_name:
+                        clip_product_name = self.product_name
+
                     # add track index in case duplicity of names in hero data
                     # INFO: this is for case where hero clip product name
                     #    is the same as current clip product name
                     if clip_product_name in data_product_name:
                         clip_product_name = (
                             f"{clip_product_name}{self.track_index}")
-                        _distrib_data["productName"] = clip_product_name
 
-                    self.log.debug(
-                        f">> clip_product_name: {clip_product_name}")
                     # in case track clip product name had been already used
                     # then add product name with clip index
                     if clip_product_name in used_names_list:
                         clip_product_name = (
                             f"{clip_product_name}{self.cs_index}"
                         )
-                        _distrib_data["productName"] = clip_product_name
 
                     self.log.debug(
                         f">> clip_product_name: {clip_product_name}")
-
-                    self.log.debug(
-                        f">> self.base_product_name: {self.base_product_name}"
-                    )
-                    self.log.debug(
-                        f">> self.track_name: {self.track_name}")
-                    # in case track name and product name is the same then add
-                    if self.base_product_name == self.track_name:
-                        _distrib_data["productName"] = self.product_name
-
+                    _distrib_data["productName"] = clip_product_name
                     # assign data to return hierarchy data to tag
                     tag_hierarchy_data = _distrib_data
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -630,9 +630,9 @@ class PublishableClip:
                 `tag_hierarchy_data` will be set only once for every
                 clip which is not hero clip.
                 """
-                _distrib_data = deepcopy(hero_data)
-                _distrib_data.update({"heroTrack": False})
                 if _in <= self.clip_in and _out >= self.clip_out:
+                    _distrib_data = deepcopy(hero_data)
+                    _distrib_data["heroTrack"] = False
                     data_product_name = hero_data["productName"]
                     used_names_list = self.vertical_clip_used.setdefault(
                         data_product_name, [])

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -278,8 +278,11 @@ class CreatorWidget(QtWidgets.QDialog):
             elif v["type"] == "QSpinBox":
                 data[k]["value"] = self.create_row(
                     content_layout, "QSpinBox", v["label"],
-                    setValue=v["value"], setMinimum=0,
-                    setMaximum=100000, setToolTip=tool_tip)
+                    setMaximum=100000,
+                    setMinimum=0,
+                    setValue=v["value"],
+                    setToolTip=tool_tip,
+                )
         return data
 
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -633,7 +633,9 @@ class PublishableClip:
                     data_product_name = hero_data["productName"]
                     used_names_list = self.vertical_clip_used.setdefault(
                         data_product_name, [])
-
+                    self.log.debug(
+                        f"used_names_list: {used_names_list}"
+                    )
                     clip_product_name = self.product_name
                     # add track index in case duplicity of names in hero data
                     # INFO: this is for case where hero clip product name

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -661,6 +661,14 @@ class PublishableClip:
                         )
                         _distrib_data["productName"] = clip_product_name
 
+                    self.log.debug(
+                        f">> clip_product_name: {clip_product_name}")
+
+                    self.log.debug(
+                        f">> self.base_product_name: {self.base_product_name}"
+                    )
+                    self.log.debug(
+                        f">> self.track_name: {self.track_name}")
                     # in case track name and product name is the same then add
                     if self.base_product_name == self.track_name:
                         _distrib_data["productName"] = self.product_name

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -641,8 +641,8 @@ class PublishableClip:
                     )
                     clip_product_name = self.product_name
                     self.log.debug(
-                        f">> clip_product_name: {clip_product_name}"
-                    )
+                        f">> clip_product_name: {clip_product_name}")
+
                     # add track index in case duplicity of names in hero data
                     # INFO: this is for case where hero clip product name
                     #    is the same as current clip product name
@@ -651,6 +651,8 @@ class PublishableClip:
                             f"{clip_product_name}{self.track_index}")
                         _distrib_data["productName"] = clip_product_name
 
+                    self.log.debug(
+                        f">> clip_product_name: {clip_product_name}")
                     # in case track clip product name had been already used
                     # then add product name with clip index
                     if clip_product_name in used_names_list:

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -659,9 +659,17 @@ class PublishableClip:
                 # in case track clip product name had been already used
                 # then add product name with clip index
                 if clip_product_name in used_names_list:
-                    clip_product_name = (
+                    _clip_product_name = (
                         f"{clip_product_name}{self.cs_index}"
                     )
+                    # just in case lets validate if new name is not used
+                    # in case the track_index is the same as clip_index
+                    if _clip_product_name in used_names_list:
+                        _clip_product_name = (
+                            f"{clip_product_name}"
+                            f"{self.track_index}{self.cs_index}"
+                        )
+                    clip_product_name = _clip_product_name
 
                 self.log.debug(
                     f">> clip_product_name: {clip_product_name}")

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -652,7 +652,7 @@ class PublishableClip:
                 # add track index in case duplicity of names in hero data
                 # INFO: this is for case where hero clip product name
                 #    is the same as current clip product name
-                if clip_product_name in data_product_name:
+                if clip_product_name == data_product_name:
                     clip_product_name = (
                         f"{clip_product_name}{self.track_index}")
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -637,9 +637,12 @@ class PublishableClip:
                     used_names_list = self.vertical_clip_used.setdefault(
                         data_product_name, [])
                     self.log.debug(
-                        f"used_names_list: {used_names_list}"
+                        f">> used_names_list: {used_names_list}"
                     )
                     clip_product_name = self.product_name
+                    self.log.debug(
+                        f">> clip_product_name: {clip_product_name}"
+                    )
                     # add track index in case duplicity of names in hero data
                     # INFO: this is for case where hero clip product name
                     #    is the same as current clip product name

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -628,16 +628,20 @@ class PublishableClip:
                 then skip this clip and do not add to hierarchical shared
                 metadata to them.
                 """
-                if self.clip_in < hero_in and self.clip_out > hero_out:
+
+                if self.clip_in < hero_in or self.clip_out > hero_out:
                     continue
 
                 _distrib_data = deepcopy(hero_data)
                 _distrib_data["heroTrack"] = False
+                # form used clip unique key
                 data_product_name = hero_data["productName"]
+                new_clip_name = hero_data["newClipName"]
 
                 # get used names list for duplicity check
                 used_names_list = self.vertical_clip_used.setdefault(
-                    data_product_name, [])
+                    f"{new_clip_name}{data_product_name}", []
+                )
                 self.log.debug(
                     f">> used_names_list: {used_names_list}"
                 )

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -44,7 +44,7 @@ class FlamePrelaunch(PreLaunchHook):
         self.flame_python_exe = _env["AYON_FLAME_PYTHON_EXEC"]
 
         # add it to data for other hooks
-        self.data["fusion_python_executable"] = self.flame_python_exe
+        self.data["flame_python_executable"] = self.flame_python_exe
 
         self.flame_pythonpath = _env["AYON_FLAME_PYTHONPATH"]
 

--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -30,7 +30,7 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
     def inner_execute(self):
         self.log.debug("Check for OpenTimelineIO installation.")
 
-        flame_py_exe = self.data.get("fusion_python_executable")
+        flame_py_exe = self.data.get("flame_python_executable")
         if not flame_py_exe:
             self.log.warning("Flame python executable not found.")
             return

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -423,7 +423,7 @@ def _create_otio_timeline(sequence):
     metadata.update({
         "ayon.timeline.width": int(sequence.width),
         "ayon.timeline.height": int(sequence.height),
-        "ayon.timeline.pixelAspect": 1
+        "ayon.timeline.pixelAspect": float(1)
     })
 
     rt_start_time = create_otio_rational_time(

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -1,8 +1,5 @@
 from copy import deepcopy
-from ayon_core.lib import Logger
 import ayon_flame.api as ayfapi
-
-log = Logger.get_logger(__name__)
 
 
 class CreateShotClip(ayfapi.Creator):
@@ -62,7 +59,7 @@ class CreateShotClip(ayfapi.Creator):
         sorted_selected_segments.extend(unsorted_selected_segments)
 
         kwargs = {
-            "log": log,
+            "log": self.log,
             "ui_inputs": results_back,
             "basicProductData": self.data,
             "productType": self.data["productType"],

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -1,5 +1,8 @@
 from copy import deepcopy
+from ayon_core.lib import Logger
 import ayon_flame.api as ayfapi
+
+log = Logger.get_logger(__name__)
 
 
 class CreateShotClip(ayfapi.Creator):
@@ -59,10 +62,10 @@ class CreateShotClip(ayfapi.Creator):
         sorted_selected_segments.extend(unsorted_selected_segments)
 
         kwargs = {
-            "log": self.log,
+            "log": log,
             "ui_inputs": results_back,
             "basicProductData": self.data,
-            "productType": self.data["productType"]
+            "productType": self.data["productType"],
         }
 
         for i, segment in enumerate(sorted_selected_segments):

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -1,10 +1,8 @@
-import logging
 from copy import deepcopy
+from ayon_core.lib import Logger
 import ayon_flame.api as ayfapi
 
-log = logging.getLogger(__name__)
-# debug level
-log.setLevel(logging.DEBUG)
+log = Logger.get_logger(__name__)
 
 
 class CreateShotClip(ayfapi.Creator):

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -1,8 +1,10 @@
+import logging
 from copy import deepcopy
-from ayon_core.lib import Logger
 import ayon_flame.api as ayfapi
 
-log = Logger.get_logger(__name__)
+log = logging.getLogger(__name__)
+# debug level
+log.setLevel(logging.DEBUG)
 
 
 class CreateShotClip(ayfapi.Creator):

--- a/client/ayon_flame/plugins/publish/collect_timeline_instances.py
+++ b/client/ayon_flame/plugins/publish/collect_timeline_instances.py
@@ -223,8 +223,7 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
             ):
                 continue
 
-            self._get_xml_preset_attrs(
-                attributes, split)
+            self._get_xml_preset_attrs(attributes, split)
 
         # add xml overrides resolution to instance data
         xml_overrides = attributes["xml_overrides"]

--- a/client/ayon_flame/plugins/publish/collect_timeline_instances.py
+++ b/client/ayon_flame/plugins/publish/collect_timeline_instances.py
@@ -210,6 +210,8 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
         }
         # search for `:`
         for split in self._split_comments(comment):
+            self.log.debug(f"__ split: {split}")
+
             # make sure we ignore if not `:` in key
             if ":" not in split:
                 continue

--- a/client/ayon_flame/plugins/publish/collect_timeline_instances.py
+++ b/client/ayon_flame/plugins/publish/collect_timeline_instances.py
@@ -234,6 +234,18 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
         return attributes
 
     def _get_xml_preset_attrs(self, attributes, split):
+        """Helper function to get xml preset attributes from comments
+
+        Example of comment:
+        `resolution:1920x1080;pixelRatio:1.5`
+
+        Args:
+            attributes (dict): attributes dict to update
+            split (str): string to split
+
+        Returns:
+            None
+        """
 
         # split to key and value
         key, value = split.split(":")
@@ -273,7 +285,7 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
             res_group = NUM_PATTERN.findall(value)
             # check if aspect was also defined
             # 1920x1080x1.5
-            aspect = res_group[2] if len(res_group) > 2 else 1
+            aspect = res_group[2] if len(res_group) > 2 else float(1)
 
             width = int(res_group[0])
             height = int(res_group[1])

--- a/client/ayon_flame/plugins/publish/collect_timeline_instances.py
+++ b/client/ayon_flame/plugins/publish/collect_timeline_instances.py
@@ -217,10 +217,7 @@ class CollectTimelineInstances(pyblish.api.ContextPlugin):
 
             # make sure we ignore if not `:` in key
             # of if there is more than one `:` in key
-            if (
-                ":" not in split
-                or split.count(":") > 1
-            ):
+            if split.count(":") != 1:
                 continue
 
             self._get_xml_preset_attrs(attributes, split)

--- a/client/ayon_flame/plugins/publish/collect_timeline_otio.py
+++ b/client/ayon_flame/plugins/publish/collect_timeline_otio.py
@@ -22,7 +22,6 @@ class CollecTimelineOTIO(pyblish.api.ContextPlugin):
         with ayfapi.maintained_segment_selection(sequence) as selected_seg:
             otio_timeline = flame_export.create_otio_timeline(sequence)
 
-
             # update context with main project attributes
             timeline_data = {
                 "flameProject": project,


### PR DESCRIPTION
## Changelog Description
*   **Fixing:** The creator displays 99 but should show 1001 at the workfile start.
*   Non-hero vertical synchronized clips with multiple clips on one track now include a clip index in the product name to prevent duplicate names.

## Additional info
* Since the issue with multiple `:` in clip comments was breaking our sponsoring clients workflow for #14 and #27 this might be fixing those issues too.  
* added some additional debug logs and also creator's plugin was not logging so own logger needed to be added

resolves #14
resolves #21
resolves #27