### PR TITLE
Fix OTIO export for Flame 

### DIFF
--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -218,7 +218,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
     duration = int(clip_data["source_duration"])
 
     # get file info for path and start frame
-    frame_start = media_info.start_frame or 0
+    media_start = media_info.start_frame or 0
     fps = fps or media_info.fps or CTX.get_fps()
 
     path = clip_data["fpath"]
@@ -234,7 +234,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
     is_sequence = frame_number = utils.get_frame_from_filename(file_name)
     if is_sequence:
         file_head = file_name.split(frame_number)[0]
-        media_start = int(frame_number)
+        start_frame = int(frame_number)
         padding = len(frame_number)
 
         metadata.update({
@@ -250,7 +250,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
                 target_url_base=dirname + os.sep,
                 name_prefix=file_head,
                 name_suffix=extension,
-                start_frame=frame_start,
+                start_frame=start_frame,
                 frame_zero_padding=padding,
                 rate=fps,
                 available_range=create_otio_time_range(

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -234,7 +234,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
     is_sequence = frame_number = utils.get_frame_from_filename(file_name)
     if is_sequence:
         file_head = file_name.split(frame_number)[0]
-        frame_start = int(frame_number)
+        media_start = int(frame_number)
         padding = len(frame_number)
 
         metadata.update({
@@ -254,7 +254,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
                 frame_zero_padding=padding,
                 rate=fps,
                 available_range=create_otio_time_range(
-                    frame_start,
+                    media_start,
                     duration,
                     fps
                 )
@@ -270,7 +270,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
         otio_ex_ref_item = otio.schema.ExternalReference(
             target_url=reformated_path,
             available_range=create_otio_time_range(
-                frame_start,
+                media_start,
                 duration,
                 fps
             )

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -218,8 +218,8 @@ def create_otio_reference(clip_data, media_info, fps=None):
     duration = int(clip_data["source_duration"])
 
     # get file info for path and start frame
-    frame_start = 0
-    fps = fps or CTX.get_fps()
+    frame_start = media_info.start_frame or 0
+    fps = fps or media_info.fps or CTX.get_fps()
 
     path = clip_data["fpath"]
 
@@ -286,8 +286,6 @@ def create_otio_clip(clip_data):
     from ayon_flame.api import MediaInfoFile, TimeEffectMetadata
 
     segment = clip_data["PySegment"]
-
-    import rpdb ; rpdb.Rpdb().set_trace()
 
     # calculate source in
     media_info = MediaInfoFile(clip_data["fpath"], logger=log)
@@ -359,8 +357,10 @@ def create_otio_clip(clip_data):
     media_reference = create_otio_reference(clip_data, media_info, media_fps)
 
     # create source range
+    available_media_start = media_reference.available_range.start_time
+    conformed_media_start = available_media_start.value_rescaled_to(CTX.get_fps())
     source_range = create_otio_time_range(
-        source_in,
+        conformed_media_start + source_in,
         _clip_record_duration,
         CTX.get_fps()
     )

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -287,6 +287,8 @@ def create_otio_clip(clip_data):
 
     segment = clip_data["PySegment"]
 
+    import rpdb ; rpdb.Rpdb().set_trace()
+
     # calculate source in
     media_info = MediaInfoFile(clip_data["fpath"], logger=log)
     media_timecode_start = media_info.start_frame
@@ -356,7 +358,7 @@ def create_otio_clip(clip_data):
     # create media reference
     media_reference = create_otio_reference(clip_data, media_info, media_fps)
 
-    # creatae source range
+    # create source range
     source_range = create_otio_time_range(
         source_in,
         _clip_record_duration,


### PR DESCRIPTION
## Changelog Description
Fixes custom AYON OTIO export for Flame.

* embedded timecode not detected properly for image sequence and movies
* image sequence `source_range` was relative to the `available_range`

##Additional info
Tested on Flame 2024.2.2.

## Testing notes:

I have created a sequence in Flame under `Reel 5` that creates a 25fps timeline with a mix of:
* regular movie
* movie with embedded timecode
* regular image sequence
* image sequence with embedded timecode

Here is the code to validate the results:
```python
import ayon_flame.api as ayfapi
from ayon_flame.otio import flame_export

print("toto: ", ayfapi.CTX.selection)

seq = ayfapi.get_current_sequence(ayfapi.CTX.selection)
#with ayfapi.maintained_segment_selection(seq):
otio_timeline = flame_export.create_otio_timeline(seq)

print(otio_timeline)
v1 = otio_timeline.video_tracks()[0]
v2 = otio_timeline.video_tracks()[1]

tc_clip = v1.find_clips()[0]
notc_clip = v1.find_clips()[1]
tc_img_clip = v2.find_clips()[0]
notc_img_clip = v2.find_clips()[1]


# QT embedded timecode
tc_clip.available_range()  # TimeRange(RationalTime(86400, 24), RationalTime(100, 24))
tc_clip.source_range  # TimeRange(RationalTime(90000, 25), RationalTime(100, 25))

# QT no embedded timecode
notc_clip.available_range()  # TimeRange(RationalTime(0, 25), RationalTime(101, 25))
notc_clip.source_range  # TimeRange(RationalTime(0, 25), RationalTime(101, 25))

# Img srquene (embedded timecode)
tc_img_clip.available_range()  #TimeRange(RationalTime(87399, 24), RationalTime(101, 24))
tc_img_clip.source_range  #TimeRange(RationalTime(91040.6, 25), RationalTime(101, 25))

# Img sequence (no embedded timecode)
notc_img_clip.available_range()  # TimeRange(RationalTime(1000, 25), RationalTime(101, 25))
notc_img_clip.source_range  # TimeRange(RationalTime(1000, 25), RationalTime(101, 25))
```
