### PR TITLE
Implement project metadata feature through WireTapCom.

### DIFF
--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -6,6 +6,7 @@ import os
 import sys
 import subprocess
 import json
+import tempfile
 import xml.dom.minidom as minidom
 from copy import deepcopy
 import datetime
@@ -458,6 +459,76 @@ class WireTapCom(object):
             RuntimeError("Cannot set colorspace {} on project {}".format(
                 color_policy, project_name
             ))
+
+    @staticmethod
+    def get_project_metadata(project_name):
+        """Retrieve project metadata as XML.
+
+        Args:
+            project_name (str): name of the project.
+
+        Returns:
+            str. The metadata formatted as XML.
+
+        Raises:
+            RuntimeError. When metadata could not be fetched.            
+        """
+        wiretap_tools_dir = os.getenv("AYON_WIRETAP_TOOLS")
+        get_metadata_cmd = os.path.join(
+            wiretap_tools_dir,
+            "wiretap_get_metadata",
+        )
+
+        cmd = [
+            get_metadata_cmd,
+            "-n", f"/projects/{project_name}",
+            "-s", "XML"
+        ]
+
+        try:
+            return subprocess.check_output(cmd)
+
+        except subprocess.CalledProcessError as error:
+            raise RuntimeError(
+                f"Cannot retrieve metadata for {project_name}"
+            ) from error
+
+    @staticmethod
+    def set_project_metadata(project_name, xml_metadata):
+        """Retrieve project metadata as XML.
+
+        Args:
+            project_name (str): name of the project.
+            xml_metadata (str): new metadata formatted as XML.
+
+        Returns:
+            bool. Has the metadata been edited.
+        """
+        wiretap_tools_dir = os.getenv("AYON_WIRETAP_TOOLS")
+        set_metadata_cmd = os.path.join(
+            wiretap_tools_dir,
+            "wiretap_set_metadata",
+        )
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            tmp_file.write(xml_metadata.encode())
+
+        cmd = [
+            set_metadata_cmd,
+            "-n", f"/projects/{project_name}",
+            "-s", "XML",
+            "-f", tmp_file.name
+        ]
+
+        try:
+            subprocess.check_output(cmd)
+            return True
+
+        except subprocess.CalledProcessError:
+            return False
+
+        finally:
+            os.remove(tmp_file.name)
 
 
 def _subprocess_preexec_fn():


### PR DESCRIPTION
## Changelog Description
This PR aims to provide the possibility to edit project metadata through existing `WireTapCom` object.
https://help.autodesk.com/view/FLAME/2025/ENU/?guid=Flame_API_Wiretap_SDK_FAQs_and_Troubleshooting_General_API_html

This would allow to save workfile metadata as `Nickname` as suggested here:
https://forums.autodesk.com/t5/flame-forum/store-persistent-variable-with-flame-project/td-p/9437717

Unfortunately this seems to be very fragile right now as it creates crash report.

**TODO**: 
* [X] Poke community forums and helps to find other suggestions
* [ ] Find issue and implement work-around
* [ ] Use this to implement `create_workfile` creator instead of the `JSON` side-car file.