### PR TITLE
AY-7250 Fix plugins settings and OTIO export for shot creator.

### DIFF
--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -824,9 +824,12 @@ class MediaInfoFile(object):
             self.log.debug("drop frame: {}".format(self.drop_mode))
             # get all resolution related data and assign them
             self._get_resolution_info_from_origin(xml_data)
-            self.log.debug("width: {}".format(self.width))
-            self.log.debug("height: {}".format(self.height))
-            self.log.debug("pixel aspect: {}".format(self.pixel_aspect))
+
+            # log image-based info if not a pure audio media
+            if hasattr("width", self):
+                self.log.debug("width: {}".format(self.width))
+                self.log.debug("height: {}".format(self.height))
+                self.log.debug("pixel aspect: {}".format(self.pixel_aspect))
 
             self.clip_data = xml_data
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -825,11 +825,13 @@ class MediaInfoFile(object):
             # get all resolution related data and assign them
             self._get_resolution_info_from_origin(xml_data)
 
-            # log image-based info if not a pure audio media
-            if hasattr(self, "width"):
+            try:
                 self.log.debug("width: {}".format(self.width))
                 self.log.debug("height: {}".format(self.height))
                 self.log.debug("pixel aspect: {}".format(self.pixel_aspect))
+
+            except AttributeError:
+                self.log.debug("audio: true")
 
             self.clip_data = xml_data
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -826,7 +826,7 @@ class MediaInfoFile(object):
             self._get_resolution_info_from_origin(xml_data)
 
             # log image-based info if not a pure audio media
-            if hasattr("width", self):
+            if hasattr(self, "width"):
                 self.log.debug("width: {}".format(self.width))
                 self.log.debug("height: {}".format(self.height))
                 self.log.debug("pixel aspect: {}".format(self.pixel_aspect))

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -209,6 +209,9 @@ def create_otio_reference(clip_data, media_info, fps=None):
     metadata = _get_metadata(clip_data)
 
     # Add image-based metadata if not a pure audio media
+    # TODO: what happens if media is image-based but not width
+    # can be reached ?
+    # (could use ayon_core.lib.transcoding.get_otio_info_for_input)
     if hasattr(media_info, "width"):
         metadata.update(
             {

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -208,13 +208,16 @@ def create_otio_markers(otio_item, item):
 def create_otio_reference(clip_data, media_info, fps=None):
     metadata = _get_metadata(clip_data)
 
-    metadata.update(
-        {
-            "ayon.source.width": media_info.width,
-            "ayon.source.height": media_info.height,
-            "ayon.source.pixelAspect": media_info.pixel_aspect,
-        }
-    )
+    # Add image-based metadata if not a pure audio media
+    if hasattr("width", self):
+        metadata.update(
+            {
+                "ayon.source.width": media_info.width,
+                "ayon.source.height": media_info.height,
+                "ayon.source.pixelAspect": media_info.pixel_aspect,
+            }
+        )
+
     duration = int(clip_data["source_duration"])
 
     # get file info for path and start frame

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -209,7 +209,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
     metadata = _get_metadata(clip_data)
 
     # Add image-based metadata if not a pure audio media
-    if hasattr("width", media_info):
+    if hasattr(media_info, "width"):
         metadata.update(
             {
                 "ayon.source.width": media_info.width,

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -209,7 +209,7 @@ def create_otio_reference(clip_data, media_info, fps=None):
     metadata = _get_metadata(clip_data)
 
     # Add image-based metadata if not a pure audio media
-    if hasattr("width", self):
+    if hasattr("width", media_info):
         metadata.update(
             {
                 "ayon.source.width": media_info.width,

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -143,6 +143,11 @@ class _FlameInstanceCreator(plugin.HiddenFlameCreator):
             segment_item = created_inst.transient_data["segment_item"]
             marker_data = ayfapi.get_segment_data_marker(segment_item)
 
+            # Backwards compatible (Deprecated since 24/09/05)
+            # ignore instance if no existing marker data
+            if marker_data is None:
+                continue
+
             try:
                 instances_data = marker_data[_CONTENT_ID]
 

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -387,7 +387,7 @@ OTIO file.
                 "segmentIndex",
                 label="Segment Index",
                 tooltip="Take number from segment index",
-                default=True,
+                default=presets.get("segmentIndex", True),
             ),
             NumberDef(
                 "countFrom",
@@ -490,13 +490,13 @@ OTIO file.
                 "export_audio",
                 label="Include audio",
                 tooltip="Process subsets with corresponding audio",
-                default=False,
+                default=presets.get("export_audio", False),
             ),
             BoolDef(
                 "sourceResolution",
                 label="Source resolution",
                 tooltip="Is resolution taken from timeline or source?",
-                default=False,
+                default=presets.get("sourceResolution", False),
             ),
 
             # shotAttr
@@ -525,19 +525,19 @@ OTIO file.
                 "includeHandles",
                 label="Include handles",
                 tooltip="Should the handles be included?",
-                default=False,
+                default=presets.get("includeHandles", True),
             ),
             BoolDef(
                 "retimedHandles",
                 label="Retimed handles",
                 tooltip="Should the handles be retimed?",
-                default=True,
+                default=presets.get("retimedHandles", True),
             ),
             BoolDef(
                 "retimedFramerange",
                 label="Retimed framerange",
                 tooltip="Should the framerange be retimed?",
-                default=True,
+                default=presets.get("retimedFramerange", True),
             ),
         ]
 

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -63,13 +63,11 @@ class CreateShotClipModel(BaseSettingsModel):
     export_audio: bool = SettingsField(
         False,
         title="Include audio",
-        section="Process subsets with corresponding audio"
     )
 
     sourceResolution: bool = SettingsField(
         False,
         title="Source resolution",
-        section="Get shot resolution from clip source resolution"
     )
 
     workfileFrameStart: int = SettingsField(

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -60,6 +60,18 @@ class CreateShotClipModel(BaseSettingsModel):
         section="Vertical Synchronization Of Attributes"
     )
 
+    export_audio: bool = SettingsField(
+        False,
+        title="Include audio",
+        section="Process subsets with corresponding audio"
+    )
+
+    sourceResolution: bool = SettingsField(
+        False,
+        title="Source resolution",
+        section="Get shot resolution from clip source resolution"
+    )
+
     workfileFrameStart: int = SettingsField(
         1001,
         title="Workfiles Start Frame",


### PR DESCRIPTION
## Changelog Description

resolve #42 

Various bugfixes from feedback on `ayon-flame-1.0.0`:
* [x] Ensure OTIO timeline with pure audio files (`.mp3`, `.wav`, ...) get exported properly
* [x] Make all creator settings inherit from server settings 
* [x] Ensure instance update which are not associated to a marker do not fail anymore (legacy workfile compatibility) 

## Testing notes:
1. Create the new package and upload it to the server to test out new server settings
2. Ensure those settings are properly reported by default in the creator
3. Load pure audio media in the timeline and attempt to export audio products from the sequence
