### PR TITLE
Fix OTIO sequence export.

### DIFF
--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -232,14 +232,14 @@ def create_otio_reference(clip_data, media_info, fps=None):
     otio_ex_ref_item = None
 
     # match range pattern e.g. "foo_[1001-1010].ext"
-    regex_sequence = r"\D*\[(\d)*\-(\d)*\]\D*"
+    regex_sequence = r".*\[(?P<start_frame>\d*)-(?P<end_frame>\d*)\].?"
     is_sequence = re.match(
         regex_sequence,
         media_info.file_pattern
     )
 
     if is_sequence:
-        frame_number = utils.get_frame_from_filename(file_name)
+        frame_number = is_sequence.group("start_frame")
         file_head = file_name.split(frame_number)[0]
         start_frame = int(frame_number)
         padding = len(frame_number)

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -231,15 +231,14 @@ def create_otio_reference(clip_data, media_info, fps=None):
 
     otio_ex_ref_item = None
 
-    # match range pattern e.g. "foo_[1001-1010].ext"
-    regex_sequence = r".*\[(?P<start_frame>\d*)-(?P<end_frame>\d*)\].?"
-    is_sequence = re.match(
-        regex_sequence,
+    sequence_match = re.match(
+        # match range pattern e.g. "foo_[1001-1010].ext"
+        r".*\[(?P<start_frame>\d*)-(?P<end_frame>\d*)\].?",
         media_info.file_pattern
     )
 
-    if is_sequence:
-        frame_number = is_sequence.group("start_frame")
+    if sequence_match:
+        frame_number = sequence_match.group("start_frame")
         file_head = file_name.split(frame_number)[0]
         start_frame = int(frame_number)
         padding = len(frame_number)

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -231,8 +231,15 @@ def create_otio_reference(clip_data, media_info, fps=None):
 
     otio_ex_ref_item = None
 
-    is_sequence = frame_number = utils.get_frame_from_filename(file_name)
+    # match range pattern e.g. "foo_[1001-1010].ext"
+    regex_sequence = r"\D*\[(\d)*\-(\d)*\]\D*"
+    is_sequence = re.match(
+        regex_sequence,
+        media_info.file_pattern
+    )
+
     if is_sequence:
+        frame_number = utils.get_frame_from_filename(file_name)
         file_head = file_name.split(frame_number)[0]
         start_frame = int(frame_number)
         padding = len(frame_number)
@@ -259,16 +266,25 @@ def create_otio_reference(clip_data, media_info, fps=None):
                     fps
                 )
             )
-        except AttributeError:
-            pass
 
-    if not otio_ex_ref_item:
-        dirname, file_name = os.path.split(path)
-        file_name = utils.get_reformatted_filename(file_name, padded=False)
-        reformated_path = os.path.join(dirname, file_name)
-        # in case old OTIO or video file create `ExternalReference`
+        # in case old OTIO create sequence as `ExternalReference`
+        except AttributeError:
+            dirname, file_name = os.path.split(path)
+            file_name = utils.get_reformatted_filename(file_name, padded=False)
+            reformated_path = os.path.join(dirname, file_name)
+            otio_ex_ref_item = otio.schema.ExternalReference(
+                target_url=reformated_path,
+                available_range=create_otio_time_range(
+                    media_start,
+                    duration,
+                    fps
+                )
+            )
+
+    # video/audio file create `ExternalReference`
+    else:
         otio_ex_ref_item = otio.schema.ExternalReference(
-            target_url=reformated_path,
+            target_url=path,
             available_range=create_otio_time_range(
                 media_start,
                 duration,


### PR DESCRIPTION
## Changelog Description

Fix bug where media path ending with numbers get detected as sequence media.

## Additional review information
Issue reported on our discord (private link).
https://discord.com/channels/517362899170230292/1272886803585826869

While doing this I realized that still image are not supported by our publisher right now (out of the scope of this PR).

## Testing notes:
(tested on our own Flame instance and also client one with their content/timeline 30+ clips)

1. Import a media finishing with a number e.g. `foo.2024_01.mov` in the Flame timeline
2. Try to publish a shot/clip from it
3. Ensure publish goes through correctly
