### PR TITLE
More consolidations on Flame OTIO exporter

### DIFF
--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -379,10 +379,12 @@ def create_otio_clip(clip_data):
 
     # create source range
     available_media_start = media_reference.available_range.start_time
-    conformed_media_start = available_media_start.value_rescaled_to(
-        CTX.get_fps())
+    source_in_offset = otio.opentime.RationalTime(source_in, available_media_start.rate)
+    src_in = available_media_start + source_in_offset
+    conformed_src_in = src_in.rescaled_to(CTX.get_fps())
+
     source_range = create_otio_time_range(
-        conformed_media_start + source_in,
+        conformed_src_in.value,  # no rounding to preserve accuracy
         _clip_record_duration,
         CTX.get_fps()
     )


### PR DESCRIPTION
## Changelog Description
help resolve https://github.com/ynput/ayon-flame/issues/28
* [X] We were loosing some accuracy on OTIO export for source range start_time, this was causing rounding issues with longest frame range.

## Additional review information
TBD

## Testing notes:
1. Create a clip in flame with a long frame range (`e.g. start_frame > 900,000` at `24.0 fps`)
2. Drag and drop on a `23.976` sequence while preserving clip duration
3. Trim clip to specific frame input output
4. Export sequence to OTIO and ensure source range of the clip match input frame when rescaled back to `24.0 fps`
