### PR TITLE
Chore: Adjust frame sequence detection

### DIFF
--- a/client/ayon_flame/otio/utils.py
+++ b/client/ayon_flame/otio/utils.py
@@ -1,9 +1,14 @@
+import os
 import re
 import opentimelineio as otio
 import logging
+
+from ayon_core.lib.transcoding import IMAGE_EXTENSIONS
+
+
 log = logging.getLogger(__name__)
 
-FRAME_PATTERN = re.compile(r"[\._](\d+)[\.]")
+FRAME_PATTERN = r"[\._](\d+)"
 
 
 def timecode_to_frames(timecode, framerate):
@@ -78,15 +83,20 @@ def get_frame_from_filename(filename):
         filename (str): file name
 
     Returns:
-        int: sequence frame number
+        str: sequence frame number if found or None
 
     Example:
         def get_frame_from_filename(path):
-            ("plate.0001.exr") > 0001
+            ("plate.0001.exr") > "0001"
 
     """
+    _, ext = os.path.splitext(filename)
 
-    found = re.findall(FRAME_PATTERN, filename)
+    if ext.lower() not in IMAGE_EXTENSIONS:
+        return None
+
+    pattern = re.compile(FRAME_PATTERN + ext)
+    found = re.findall(pattern, filename)
 
     return found.pop() if found else None
 

--- a/client/ayon_flame/otio/utils.py
+++ b/client/ayon_flame/otio/utils.py
@@ -83,7 +83,7 @@ def get_frame_from_filename(filename):
         filename (str): file name
 
     Returns:
-        str: sequence frame number if found or None
+        Optional[str]: sequence frame number if found or None
 
     Example:
         def get_frame_from_filename(path):

--- a/client/ayon_flame/otio/utils.py
+++ b/client/ayon_flame/otio/utils.py
@@ -95,8 +95,8 @@ def get_frame_from_filename(filename):
     if ext.lower() not in IMAGE_EXTENSIONS:
         return None
 
-    pattern = re.compile(FRAME_PATTERN + ext)
-    found = re.findall(pattern, filename)
+    pattern = re.compile(FRAME_PATTERN + re.escape(ext))
+    found = pattern.findall(filename)
 
     return found.pop() if found else None
 


### PR DESCRIPTION
## Changelog Description
While investigating on https://github.com/ynput/ayon-flame/issues/61 I realized on frame sequence detection was not strong enough. And gave false positive with some videos.

partly resolve: #61 

## Testing notes:

You can run this small sniper in the AYON console to check the fix:
```python
from ayon_core.lib.transcoding import IMAGE_EXTENSIONS
import os
import re

FRAME_PATTERN = r"[\._](\d+)"

def get_frame_from_filename(filename):
    """
    Return sequence number from Flame path style

    Args:
        filename (str): file name

    Returns:
        str: sequence frame number if found or None

    Example:
        def get_frame_from_filename(path):
            ("plate.0001.exr") > "0001"

    """
    _, ext = os.path.splitext(filename)

    if ext.lower() not in IMAGE_EXTENSIONS:
        return None

    pattern = re.compile(FRAME_PATTERN + ext)
    found = re.findall(pattern, filename)

    return found.pop() if found else None

for filename in (
    "toto.exr",  # expected None
    "toto.1001.exr",  # expected 1001
    "foo_1001.2002_abc_1025.JPEG",  # expected 1025
    "SEA_0100.941205_V1-0011.mov,  # expected None (used to be problematic)
"):
    print(filename, " -> ", get_frame_from_filename(filename))
```
