### PR TITLE
Expose sourceResolution attribute as creator_attribute for shot instance.

### DIFF
--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -199,7 +199,7 @@ class FlameShotInstanceCreator(_FlameInstanceCreator):
         instance_attributes = CLIP_ATTR_DEFS
         instance_attributes.append(
             BoolDef(
-                "sourceResolution",
+                "useSourceResolution",
                 label="Set shot resolution from plate",
                 tooltip="Is resolution taken from timeline or source?",
                 default=False,
@@ -702,7 +702,7 @@ OTIO file.
                                 "retimedFramerange": pre_create_data[
                                     "retimedFramerange"
                                 ],
-                                "sourceResolution": sub_instance_data[
+                                "useSourceResolution": sub_instance_data[
                                     "sourceResolution"],
                             },
                             "label": f"{shot_folder_path} shot",
@@ -839,7 +839,7 @@ OTIO file.
                 "includeHandles": sub_instance_data["includeHandles"],
                 "retimedHandles": sub_instance_data["retimedHandles"],
                 "retimedFramerange": sub_instance_data["retimedFramerange"],
-                "sourceResolution": sub_instance_data["sourceResolution"],
+                "useSourceResolution": sub_instance_data["sourceResolution"],
             },
             "label": (
                 f"{sub_instance_data['folderPath']} shot"

--- a/client/ayon_flame/plugins/publish/collect_shots.py
+++ b/client/ayon_flame/plugins/publish/collect_shots.py
@@ -254,7 +254,7 @@ class CollectShot(pyblish.api.InstancePlugin):
         assert data.get("otioClip"), "Missing `otioClip` data"
 
         # solve source resolution option
-        if data["creator_attributes"].get("sourceResolution", None):
+        if data["creator_attributes"].get("useSourceResolution", None):
             otio_clip_metadata = data[
                 "otioClip"].media_reference.metadata
             data.update({


### PR DESCRIPTION
## Changelog Description

helps resolve https://github.com/ynput/ayon-core/issues/1289

Flame `Create Publishable Clip` creator supports a sourceResolution attribute, that allow the new shot to be created to pick-up its resolution from the hero plate instead of the timeline.
This attribute was only exposed as creator level and not anymore, this PR brings it as creator_attributes for shot instance(s).

## Additional review information
This PR reports this change from Hiero
https://github.com/ynput/ayon-hiero/pull/66

and Resolve:
https://github.com/ynput/ayon-resolve/pull/60

## Testing notes:
Tested locally on Flame 2024.
1. Ensure this attribute is properly exposed for shots, for existing and new created instances.
