### PR TITLE
AY-7790 Add parenting of instances

### DIFF
--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -24,7 +24,7 @@ class HiddenFlameCreator(HiddenCreator):
     settings_category = "flame"
 
     def collect_instances(self):
-            pass
+        pass
 
     def update_instances(self, update_list):
         pass

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -114,7 +114,6 @@ class _FlameInstanceCreator(plugin.HiddenFlameCreator):
 
     def _add_instance_to_context(self, instance):
         parent_id = instance.get("parent_instance_id")
-        self.log.info(f">>>> Adding parent: {parent_id}")
         if parent_id is not None and ParentFlags is not None:
             instance.set_parent(
                 parent_id,
@@ -213,7 +212,7 @@ class FlameShotInstanceCreator(_FlameInstanceCreator):
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
-        instance_attributes = CLIP_ATTR_DEFS
+        instance_attributes = list(CLIP_ATTR_DEFS)
         instance_attributes.append(
             BoolDef(
                 "useSourceResolution",


### PR DESCRIPTION
## Changelog Description

Use parenting advantage in simple editorial workflow to visualize tree of instances in publisher.

## Additional info

The introduction of `ParentFlags` and the subsequent implementation of instance parenting.

## Testing notes:

1.  Create a clip-based instance in Flame.
2.  Verify that the instance is correctly parented to its designated parent.
3.  switch publisher instance view to other modes

closes #68 

Root issue: https://github.com/ynput/ayon-core/issues/874
