### PR TITLE
Refactors segment attribute retrieval

### DIFF
--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -574,7 +574,6 @@ def get_segment_attributes(segment):
         "source_in", "source_out"
     ]
     segment_attrs_data = {}
-    log.warning(f"dir attrs `segment_attrs`: '{dir(segment)}'")
     for attr_name in segment_attrs:
         if not hasattr(segment, attr_name):
             continue
@@ -584,13 +583,10 @@ def get_segment_attributes(segment):
         if attr_name in ["record_in", "record_out"]:
             clip_data[attr_name] = attr.relative_frame
         else:
-            log.warning(f"dir attr {attr_name}: '{dir(attr)}'")
             if hasattr(attr, "frame"):
-                log.info(f"attr {attr_name}: '{attr.frame}'")
                 clip_data[attr_name] = attr.frame
 
     clip_data["segment_timecodes"] = segment_attrs_data
-    log.info(f"clip_data: '{clip_data}'")
     return clip_data
 
 
@@ -873,7 +869,6 @@ class MediaInfoFile(object):
             str: collection basename with range of sequence
         """
         partialname = self._separate_file_head(feed_basename, feed_ext)
-        self.log.debug("__ partialname: {}".format(partialname))
 
         # make sure partial input basename is having correct extensoon
         if not partialname:

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -571,9 +571,10 @@ def get_segment_attributes(segment):
     # populate shot source metadata
     segment_attrs = [
         "record_duration", "record_in", "record_out",
-        "source_duration", "source_in", "source_out"
+        "source_in", "source_out"
     ]
     segment_attrs_data = {}
+    log.warning(f"dir attrs `segment_attrs`: '{dir(segment)}'")
     for attr_name in segment_attrs:
         if not hasattr(segment, attr_name):
             continue
@@ -583,10 +584,13 @@ def get_segment_attributes(segment):
         if attr_name in ["record_in", "record_out"]:
             clip_data[attr_name] = attr.relative_frame
         else:
-            clip_data[attr_name] = attr.frame
+            log.warning(f"dir attr {attr_name}: '{dir(attr)}'")
+            if hasattr(attr, "frame"):
+                log.info(f"attr {attr_name}: '{attr.frame}'")
+                clip_data[attr_name] = attr.frame
 
     clip_data["segment_timecodes"] = segment_attrs_data
-
+    log.info(f"clip_data: '{clip_data}'")
     return clip_data
 
 

--- a/client/ayon_flame/otio/flame_export.py
+++ b/client/ayon_flame/otio/flame_export.py
@@ -7,6 +7,8 @@ import json
 import logging
 import opentimelineio as otio
 
+from ayon_flame.api import lib
+
 from . import utils
 from . import tw_bake
 
@@ -554,66 +556,6 @@ def _get_shot_tokens_values(clip, tokens):
     return output
 
 
-def get_segment_attributes(segment):
-
-    log.debug("Segment name|hidden: {}|{}".format(
-        segment.name.get_value(), segment.hidden
-    ))
-    if (
-        segment.name.get_value() == ""
-        or segment.hidden.get_value()
-    ):
-        return None
-
-    # Add timeline segment to tree
-    clip_data = {
-        "segment_name": segment.name.get_value(),
-        "segment_comment": segment.comment.get_value(),
-        "shot_name": segment.shot_name.get_value(),
-        "tape_name": segment.tape_name,
-        "source_name": segment.source_name,
-        "fpath": segment.file_path,
-        "PySegment": segment
-    }
-
-    # add all available shot tokens
-    shot_tokens = _get_shot_tokens_values(
-        segment,
-        ["<colour space>", "<width>", "<height>", "<depth>"]
-    )
-    clip_data.update(shot_tokens)
-
-    # populate shot source metadata
-    segment_attrs = [
-        "record_duration", "record_in", "record_out",
-        "source_duration", "source_in", "source_out"
-    ]
-    segment_attrs_data = {}
-    for attr in segment_attrs:
-        if not hasattr(segment, attr):
-            continue
-        _value = getattr(segment, attr)
-
-        # Not a "valid" segment, skip it.
-        if _value is None:
-            log.warning(
-                f"Could not retrieve {attr} for {segment.name}, "
-                "ensure this is a valid clip ?"
-            )
-            return {}
-
-        segment_attrs_data[attr] = str(_value).replace("+", ":")
-
-        if attr in ["record_in", "record_out"]:
-            clip_data[attr] = _value.relative_frame
-        else:
-            clip_data[attr] = _value.frame
-
-    clip_data["segment_timecodes"] = segment_attrs_data
-
-    return clip_data
-
-
 def _get_segments_from_track(flame_track):
     """ Gather segment(s) from a flame track.
 
@@ -625,7 +567,7 @@ def _get_segments_from_track(flame_track):
     """
     all_segments = []
     for segment in flame_track.segments:
-        clip_data = get_segment_attributes(segment)
+        clip_data = lib.get_segment_attributes(segment)
         if clip_data:
             all_segments.append(clip_data)
 

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -3,7 +3,6 @@ import uuid
 
 import ayon_flame.api as ayfapi
 from ayon_flame.api import plugin, lib, pipeline
-from ayon_flame.otio import flame_export
 
 from ayon_core.pipeline.create import CreatorError, CreatedInstance
 from ayon_core.lib import BoolDef, EnumDef, TextDef, UILabelDef, NumberDef

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -691,7 +691,7 @@ OTIO file.
                 # Shot creation
                 if creator_id == shot_creator_id:
                     segment_data = lib.get_segment_attributes(segment)
-                    self.log.info(f"segment_data: '{segment_data}'")
+                    self.log.debug(f"segment_data: '{segment_data}'")
                     record_in = segment_data["record_in"]
                     record_out = segment_data["record_out"]
                     segment_duration = segment_data.get("record_duration")

--- a/client/ayon_flame/plugins/create/create_shot_clip.py
+++ b/client/ayon_flame/plugins/create/create_shot_clip.py
@@ -673,8 +673,13 @@ OTIO file.
 
                 # Shot creation
                 if creator_id == shot_creator_id:
-                    segment_data = flame_export.get_segment_attributes(segment)
-                    segment_duration = int(segment_data["record_duration"])
+                    segment_data = lib.get_segment_attributes(segment)
+                    self.log.info(f"segment_data: '{segment_data}'")
+                    record_in = segment_data["record_in"]
+                    record_out = segment_data["record_out"]
+                    segment_duration = segment_data.get("record_duration")
+                    if segment_duration is None:
+                        segment_duration = record_out - record_in + 1
                     workfileFrameStart = sub_instance_data[
                         "workfileFrameStart"]
                     sub_instance_data.update(
@@ -690,8 +695,8 @@ OTIO file.
                                 "frameStart": workfileFrameStart,
                                 "frameEnd": (
                                     workfileFrameStart + segment_duration),
-                                "clipIn": int(segment_data["record_in"]),
-                                "clipOut": int(segment_data["record_out"]),
+                                "clipIn": int(record_in),
+                                "clipOut": int(record_out),
                                 "clipDuration": segment_duration,
                                 "sourceIn": int(segment_data["source_in"]),
                                 "sourceOut": int(segment_data["source_out"]),
@@ -820,7 +825,7 @@ OTIO file.
 
         # Create parent shot instance.
         sub_instance_data = instance_data.copy()
-        segment_data = flame_export.get_segment_attributes(segment)
+        segment_data = lib.get_segment_attributes(segment)
         segment_duration = int(segment_data["record_duration"])
         workfileFrameStart = sub_instance_data["workfileFrameStart"]
         sub_instance_data.update({


### PR DESCRIPTION
Moves `get_segment_attributes` to the `ayon_flame.api.lib` module to centralize the function and avoid duplication. This change ensures consistency in how segment attributes are accessed and processed across different parts of the Ayon Flame integration, specifically during OTIO export and shot clip creation. It also adds more logging to the function.


closes #69 
