### PR TITLE
(YN-0075) Publish shot attributes on demand with setting

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -38,6 +38,10 @@ class CollectShotsModel(BaseSettingsModel):
             title="XML presets attributes parsable from segment comments"
         )
     )
+    ignore_shot_attributes_on_update: bool = SettingsField(
+        False,
+        title="Ignore shot attributes on update"
+    )
     add_tasks: list[AddTasksModel] = SettingsField(
         default_factory=list,
         title="Add tasks"
@@ -220,6 +224,7 @@ DEFAULT_PUBLISH_SETTINGS = {
                 "type": "string"
             }
         ],
+        "ignore_shot_attributes_on_update": False,
         "add_tasks": [
             {
                 "name": "compositing",


### PR DESCRIPTION
## Changelog Description
Shot attributes can be now updated on demand with Shot product instance attribute toggle.

## Testing notes:
1. publish a shot with specivic cut and duration and keep the toggle ON
2. See the shot attributes like Frame Start / End and Clip In / Out
3. publish it again but in this case disable the attribute
4. See the shot attributes did not change
