### PR TITLE
remove published clips after publish

### DIFF
--- a/client/ayon_flame/plugins/publish/extract_product_resources.py
+++ b/client/ayon_flame/plugins/publish/extract_product_resources.py
@@ -399,6 +399,12 @@ class ExtractProductResources(publish.Extractor):
                 representation_data))
 
             if export_type == "Sequence Publish":
+                publish_clips = flame.find_by_name(
+                    f"{exporting_clip.name.get_value()}_publish",
+                    parent=exporting_clip.parent
+                )
+                for publish_clip in publish_clips:
+                    flame.delete(publish_clip)
                 # at the end remove the duplicated clip
                 flame.delete(exporting_clip)
 


### PR DESCRIPTION
#96 
## Changelog Description
Deletes the publish clips for sequence publishes once the publish is complete

## Testing notes:
1. Do a publish
2. the "_publish" clips should not exist in the library
