### PR TITLE
Fixing error on extract_product_resources

### DIFF
--- a/client/ayon_flame/plugins/publish/extract_product_resources.py
+++ b/client/ayon_flame/plugins/publish/extract_product_resources.py
@@ -921,7 +921,9 @@ class ExtractProductResources(
             for library in workspace.libraries:
                 if library.name == "AYON_TEMP_EXPORT":
                     flame.delete(library)
-                    self.log.debug("Deleted existing library: AYON_TEMP_EXPORT")
+                    self.log.debug(
+                        "Deleted existing library: AYON_TEMP_EXPORT"
+                    )
                     break
 
             # Create a temp library


### PR DESCRIPTION

## Changelog Description

Existing library fails when copying segment to that library for some reason. Removing and recreating it seems to solve the issue

## Additional review information
This was discovered when testing a missing linked media publish

## Testing notes:
1. unlink media from a segment 
2. publish twice, the second time will fail as a temporary library exists from the first publish
