### PR TITLE
Current file: Collect current project/file earlier

### DIFF
--- a/client/ayon_flame/plugins/publish/collect_plate_from_reel.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_reel.py
@@ -10,7 +10,7 @@ from ayon_flame.api import lib
 class CollectReelPlate(pyblish.api.InstancePlugin):
     """Collect new plates from Reel."""
 
-    order = order = pyblish.api.CollectorOrder - 0.48
+    order = pyblish.api.CollectorOrder - 0.48
     label = "Collect Plate from Reel"
     hosts = ["flame"]
     families = ["plate"]

--- a/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
@@ -8,7 +8,7 @@ from ayon_flame.otio import utils
 class CollectTimelinePlate(pyblish.api.InstancePlugin):
     """Collect new plates from Timeline."""
 
-    order = order = pyblish.api.CollectorOrder - 0.48
+    order = pyblish.api.CollectorOrder - 0.48
     label = "Collect Plate from Timeline"
     hosts = ["flame"]
     families = ["plate"]

--- a/client/ayon_flame/plugins/publish/collect_project.py
+++ b/client/ayon_flame/plugins/publish/collect_project.py
@@ -8,7 +8,7 @@ class CollecFlameProject(pyblish.api.ContextPlugin):
     """Inject the current project data into current context."""
 
     label = "Collect Flame project"
-    order = pyblish.api.CollectorOrder - 0.492
+    order = pyblish.api.CollectorOrder - 0.5
 
     def process(self, context):
         # update context with main project attributes


### PR DESCRIPTION
## Changelog Description
Change order of collect project to run as soon as possible.

## Additional review information
This change probably does not affect anything, it is just 'clean up' of weird order `-0.492` which does not look like it has a reason to be set to this order as there is nothing that must run ahead of the plugin.
