### PR TITLE
Work-around to get Flame2026 starting on macOs. (QOpenGLWidget not found)

### DIFF
--- a/client/ayon_flame/startup/AYON_in_flame.py
+++ b/client/ayon_flame/startup/AYON_in_flame.py
@@ -2,6 +2,26 @@ from __future__ import print_function
 import sys
 from pprint import pformat
 import atexit
+import platform
+
+if platform.system() == "darwin":
+    try:
+        from qtpy import QtWidgets
+
+    # QtOpenGLWidgets is broken in Flame 2026 on macOS
+    # /opt/Autodesk/python/2026.2.2/lib/python3.11/site-packages/PySide6/
+    # QtOpenGLWidgets.abi3.so
+    # Reason: tried: '/opt/Autodesk/lib64/QtOpenGLWidgets.framework/Versions/A/
+    # QtOpenGLWidgets' (no such file),
+    except ImportError:
+        import sys
+        from unittest.mock import MagicMock
+        mock_module = MagicMock()
+        mock_module.__name__ = 'PySide6.QtOpenGLWidgets'
+        mock_module.QOpenGLWidget = MagicMock
+        sys.modules['PySide6.QtOpenGLWidgets'] = mock_module
+
+
 from qtpy import QtWidgets
 import traceback
 

--- a/client/ayon_flame/startup/AYON_in_flame.py
+++ b/client/ayon_flame/startup/AYON_in_flame.py
@@ -8,6 +8,7 @@ from pprint import pformat
 try:
     from PySide6.QtOpenGLWidgets import QOpenGLWidget  # noqa: F401
 except ImportError:
+    # https://github.com/ynput/ayon-flame/issues/120
     mock_module = types.ModuleType("PySide6.QtOpenGLWidgets")
     setattr(mock_module, "QOpenGLWidget", object())  # noqa: B010
 

--- a/client/ayon_flame/startup/AYON_in_flame.py
+++ b/client/ayon_flame/startup/AYON_in_flame.py
@@ -1,32 +1,26 @@
-from __future__ import print_function
-import sys
-from pprint import pformat
+from __future__ import print_function  # noqa: UP010
+
 import atexit
-import platform
+import sys
+import types
+from pprint import pformat
 
-if platform.system().lower() == "darwin":
-    try:
-        from qtpy import QtWidgets
+try:
+    from PySide6.QtOpenGLWidgets import QOpenGLWidget  # noqa: F401
+except ImportError:
+    mock_module = types.ModuleType("PySide6.QtOpenGLWidgets")
+    setattr(mock_module, "QOpenGLWidget", object())  # noqa: B010
 
-    # QtOpenGLWidgets is broken in Flame 2026 on macOS
-    # /opt/Autodesk/python/2026.2.2/lib/python3.11/site-packages/PySide6/
-    # QtOpenGLWidgets.abi3.so
-    # Reason: tried: '/opt/Autodesk/lib64/QtOpenGLWidgets.framework/Versions/A/
-    # QtOpenGLWidgets' (no such file),
-    except ImportError:
-        from unittest.mock import MagicMock
-        mock_module = MagicMock()
-        mock_module.__name__ = 'PySide6.QtOpenGLWidgets'
-        mock_module.QOpenGLWidget = MagicMock
-        sys.modules['PySide6.QtOpenGLWidgets'] = mock_module
+    sys.modules["PySide6.QtOpenGLWidgets"] = mock_module
+    from qtpy import QtWidgets
+    sys.modules.pop("PySide6.QtOpenGLWidgets")
 
-
-from qtpy import QtWidgets
 import traceback
 
 import ayon_flame.api as flame_api
-from ayon_flame.api import FlameHost
 from ayon_core.pipeline import install_host
+from ayon_flame.api import FlameHost
+from qtpy import QtWidgets
 
 
 def ayon_flame_install():

--- a/client/ayon_flame/startup/AYON_in_flame.py
+++ b/client/ayon_flame/startup/AYON_in_flame.py
@@ -4,7 +4,7 @@ from pprint import pformat
 import atexit
 import platform
 
-if platform.system() == "darwin":
+if platform.system().lower() == "darwin":
     try:
         from qtpy import QtWidgets
 
@@ -14,7 +14,6 @@ if platform.system() == "darwin":
     # Reason: tried: '/opt/Autodesk/lib64/QtOpenGLWidgets.framework/Versions/A/
     # QtOpenGLWidgets' (no such file),
     except ImportError:
-        import sys
         from unittest.mock import MagicMock
         mock_module = MagicMock()
         mock_module.__name__ = 'PySide6.QtOpenGLWidgets'


### PR DESCRIPTION
## Changelog Description

PySide does not fully work on macOS through Flame 2026
```python
from qtpy import QtWidgets
````
return
```
Traceback (most recent call last):
  File "/opt/Autodesk/presets/2026.2.2/shotgun/python/tk_flame_basic/../tk_multi_pythonconsole/python/app/input_widget.py", line 246, in execute
    exec(python_code, self._locals, self._locals)
  File "python input", line 5, in <module>
  File "/Users/jakub/CODE/__YNPUT/ayon-launcher/.venv/lib/python3.9/site-packages/qtpy/QtWidgets.py", line 42, in <module>
    from PySide6.QtOpenGLWidgets import QOpenGLWidget
ImportError: dlopen(/opt/Autodesk/python/2026.2.2/lib/python3.11/site-packages/PySide6/QtOpenGLWidgets.abi3.so, 0x0002): Library not loaded: @rpath/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets
  Referenced from: <8C75D572-6165-3448-91B6-B954CAD3FBA0> /opt/Autodesk/python/2026.2.2/lib/python3.11/site-packages/PySide6/QtOpenGLWidgets.abi3.so
  Reason: tried: '/opt/Autodesk/lib64/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/lib64/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/lib64/2026.2.2/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/lib64/2026.2.2/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/sw/lib/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/sw/lib/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/python/2026.2.2/lib/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/python/2026.2.2/lib/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/lib64/2026.2.2/framework/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/lib64/2026.2.2/framework/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/lib64/codecs/FFmpeg/17733.1/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/lib64/codecs/FFmpeg/17733.1/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/opt/Autodesk/lib64/codecs/LAME/2007.10.01.1/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/Autodesk/lib64/codecs/LAME/2007.10.01.1/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file), '/System/Library/Frameworks/QtOpenGLWidgets.framework/Versions/A/QtOpenGLWidgets' (no such file, not in dyld cache)
```

## Testing notes:
1. Install Flame2026 on macOs
2. Ensure Flame opens up properly through AYON
