### PR TITLE
YN-0022 Consolidate LoadClip and LoadClipBatch

### DIFF
--- a/client/ayon_flame/api/__init__.py
+++ b/client/ayon_flame/api/__init__.py
@@ -55,6 +55,7 @@ from .pipeline import (
 from .menu import (
     FlameMenuProjectConnect,
     FlameMenuTimeline,
+    FlameMenuBatch,
     FlameMenuUniversal
 )
 from .plugin import (
@@ -145,6 +146,7 @@ __all__ = [
     # menu
     "FlameMenuProjectConnect",
     "FlameMenuTimeline",
+    "FlameMenuBatch",
     "FlameMenuUniversal",
 
     # plugin

--- a/client/ayon_flame/api/__init__.py
+++ b/client/ayon_flame/api/__init__.py
@@ -84,6 +84,8 @@ from .batch_utils import (
     add_reels_to_batch,
     edit_batch_group_content,
     get_batch_from_workspace,
+    save_batch_as_consolidated_json,
+    load_batch_from_consolidated_json,
 )
 
 __all__ = [
@@ -172,5 +174,7 @@ __all__ = [
     "update_batch",
     "add_reels_to_batch",
     "edit_batch_group_content",
-    "get_batch_from_workspace"
+    "get_batch_from_workspace",
+    "save_batch_as_consolidated_json",
+    "load_batch_from_consolidated_json",
 ]

--- a/client/ayon_flame/api/__init__.py
+++ b/client/ayon_flame/api/__init__.py
@@ -32,7 +32,6 @@ from .lib import (
     maintained_object_duplication,
     maintained_temp_file_path,
     get_clip_segment,
-    get_batch_group_from_desktop,
     MediaInfoFile,
     TimeEffectMetadata
 )
@@ -80,8 +79,11 @@ from .render_utils import (
     modify_preset_file
 )
 from .batch_utils import (
-    create_batch_group,
-    create_batch_group_conent
+    create_batch,
+    update_batch,
+    add_reels_to_batch,
+    edit_batch_group_content,
+    get_batch_from_workspace,
 )
 
 __all__ = [
@@ -116,7 +118,6 @@ __all__ = [
     "maintained_object_duplication",
     "maintained_temp_file_path",
     "get_clip_segment",
-    "get_batch_group_from_desktop",
     "MediaInfoFile",
     "TimeEffectMetadata",
 
@@ -167,6 +168,9 @@ __all__ = [
     "modify_preset_file",
 
     # batch utils
-    "create_batch_group",
-    "create_batch_group_conent"
+    "create_batch",
+    "update_batch",
+    "add_reels_to_batch",
+    "edit_batch_group_content",
+    "get_batch_from_workspace"
 ]

--- a/client/ayon_flame/api/__init__.py
+++ b/client/ayon_flame/api/__init__.py
@@ -87,6 +87,9 @@ from .batch_utils import (
     get_batch_from_workspace,
     save_batch_as_consolidated_json,
     load_batch_from_consolidated_json,
+    read_node_metadata,
+    write_node_metadata,
+    clear_node_metadata,
 )
 
 __all__ = [
@@ -179,4 +182,7 @@ __all__ = [
     "get_batch_from_workspace",
     "save_batch_as_consolidated_json",
     "load_batch_from_consolidated_json",
+    "read_node_metadata",
+    "write_node_metadata",
+    "clear_node_metadata",
 ]

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -11,6 +11,41 @@ import flame
 
 log = Logger.get_logger(__name__)
 
+# Helps to identify AYON-managed nodes.
+AYON_NOTE_MARKER = "__ayon__"
+
+
+def read_node_metadata(node: flame.PyNode) -> Optional[Dict[str, Any]]:
+    """ Read AYON instance data from a node's note attribute.
+    """
+    try:
+        raw = node.note.get_value()
+    except Exception:
+        return None
+
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    return data if data.get(AYON_NOTE_MARKER) else None
+
+
+def write_node_metadata(node: flame.PyNode, data: Dict[str, Any]):
+    """ Write AYON instance data into a node's note attribute."""
+    payload = dict(data)
+    payload[AYON_NOTE_MARKER] = True
+    node.note = json.dumps(payload)
+    node.note_collapsed = True
+
+
+def clear_node_metadata(node: flame.PyNode):
+    """ Remove AYON instance data from a node's note attribute."""
+    node.note = ""
+
 
 def create_batch(
     name,
@@ -19,7 +54,7 @@ def create_batch(
     handle_start: int = 0,
     handle_end: int = 0,
 ) -> flame.PyBatch:
-    """Create Batch Group in active project's Desktop
+    """ Create Batch Group in active project's Desktop
     """
     frame_start -= handle_start
     frame_duration += handle_start + handle_end

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -1,151 +1,144 @@
+from typing import Optional, List, Dict, Any
+
+from ayon_core.lib import Logger
+
 import flame
 
 
-def create_batch_group(
+log = Logger.get_logger(__name__)
+
+
+def create_batch(
     name,
-    frame_start,
-    frame_duration,
-    update_batch_group=None,
-    **kwargs
-):
+    frame_start: int,
+    frame_duration: int,
+    handle_start: int = 0,
+    handle_end: int = 0,
+) -> flame.PyBatch:
     """Create Batch Group in active project's Desktop
-
-    Args:
-        name (str): name of batch group to be created
-        frame_start (int): start frame of batch
-        frame_end (int): end frame of batch
-        update_batch_group (PyBatch)[optional]: batch group to update
-
-    Return:
-        PyBatch: active flame batch group
     """
-    # make sure some batch obj is present
-    batch_group = update_batch_group or flame.batch
-
-    schematic_reels = kwargs.get("shematic_reels") or ['LoadedReel1']
-    shelf_reels = kwargs.get("shelf_reels") or ['ShelfReel1']
-
-    handle_start = kwargs.get("handleStart") or 0
-    handle_end = kwargs.get("handleEnd") or 0
-
     frame_start -= handle_start
     frame_duration += handle_start + handle_end
 
-    if not update_batch_group:
-        # Create batch group with name, start_frame value, duration value,
-        # set of schematic reel names, set of shelf reel names
-        batch_group = batch_group.create_batch_group(
-            name,
-            start_frame=frame_start,
-            duration=frame_duration,
-            reels=schematic_reels,
-            shelf_reels=shelf_reels
-        )
-    else:
-        batch_group.name = name
-        batch_group.start_frame = frame_start
-        batch_group.duration = frame_duration
-
-        # add reels to batch group
-        _add_reels_to_batch_group(
-            batch_group, schematic_reels, shelf_reels)
-
-        # TODO: also update write node if there is any
-        # TODO: also update loaders to start from correct frameStart
-
-    if kwargs.get("switch_batch_tab"):
-        # use this command to switch to the batch tab
-        batch_group.go_to()
-
-    return batch_group
+    return flame.batch.create_batch_group(
+        name,
+        start_frame=frame_start,
+        duration=frame_duration,
+    )
 
 
-def _add_reels_to_batch_group(batch_group, reels, shelf_reels):
-    # update or create defined reels
-    # helper variables
-    reel_names = [
-        r.name.get_value()
-        for r in batch_group.reels
-    ]
-    shelf_reel_names = [
-        r.name.get_value()
-        for r in batch_group.shelf_reels
-    ]
-    # add schematic reels
-    for _r in reels:
-        if _r in reel_names:
-            continue
-        batch_group.create_reel(_r)
-
-    # add shelf reels
-    for _sr in shelf_reels:
-        if _sr in shelf_reel_names:
-            continue
-        batch_group.create_shelf_reel(_sr)
-
-
-def create_batch_group_conent(batch_nodes, batch_links, batch_group=None):
-    """Creating batch group with links
-
-    Args:
-        batch_nodes (list of dict): each dict is node definition
-        batch_links (list of dict): each dict is link definition
-        batch_group (PyBatch, optional): batch group. Defaults to None.
-
-    Return:
-        dict: all batch nodes {name or id: PyNode}
+def update_batch(
+    batch: flame.PyBatch,
+    name: Optional[str] = None,
+    frame_start: Optional[int] = None,
+    frame_duration: Optional[int] = None,
+    handle_start: int = 0,
+    handle_end: int = 0,
+) -> flame.PyBatch:
+    """ Update provided batch with new values.
     """
-    # make sure some batch obj is present
-    batch_group = batch_group or flame.batch
+    if name:
+        batch.name = name
+    if frame_start is not None:
+        batch.start_frame = frame_start
+    if frame_duration is not None:
+        frame_duration += handle_start + handle_end
+        batch.duration = frame_duration
+
+    return batch
+
+
+def add_reels_to_batch(
+    batch: flame.PyBatch,
+    reels: Optional[List[str]] = None,
+    shelf_reels: Optional[List[str]] = None,
+):
+    """ Add reels and shelf reels to batch.
+    """
+    if reels:
+        existing_reel_names = [
+            reel.name.get_value()
+            for reel in batch.reels
+        ]
+        for new_reel in reels:
+            if new_reel not in existing_reel_names:
+                batch.create_reel(new_reel)
+
+    if shelf_reels:
+        existing_shelf_reel_names = [
+            reel.name.get_value()
+            for reel in batch.shelf_reels
+        ]
+        for new_sr in shelf_reels:
+            if new_sr not in existing_shelf_reel_names:
+                batch.create_shelf_reel(new_sr)
+
+
+def edit_batch_group_content(
+    batch: flame.PyBatch,
+    batch_nodes: List[Dict[str, Any]],  # each dict is node definition
+    batch_links: List[Dict[str, Any]]   # each dict is new link definition
+) -> Dict[str, flame.PyNode]:
     all_batch_nodes = {
-        b.name.get_value(): b
-        for b in batch_group.nodes
+        node.name.get_value(): node
+        for node in batch.nodes
     }
     for node in batch_nodes:
-        # NOTE: node_props needs to be ideally OrederDict type
-        node_id, node_type, node_props = (
-            node["id"], node["type"], node["properties"])
 
-        # get node name for checking if exists
-        node_name = node_props.pop("name", None) or node_id
-
+        # Node to edit already exists, update existing batch node
+        node_name = node["properties"].pop("name", None) or node["id"]
         if all_batch_nodes.get(node_name):
-            # update existing batch node
             batch_node = all_batch_nodes[node_name]
-        else:
-            # create new batch node
-            batch_node = batch_group.create_node(node_type)
 
-            # set name
+        # create new batch node, otherwise
+        else:
+            batch_node = batch.create_node(node["type"])
             batch_node.name.set_value(node_name)
+            all_batch_nodes[node["id"]] = batch_node
 
         # set attributes found in node props
-        for key, value in node_props.items():
-            if not hasattr(batch_node, key):
-                continue
-            setattr(batch_node, key, value)
-
-        # add created node for possible linking
-        all_batch_nodes[node_id] = batch_node
+        for key, value in node["properties"].items():
+            if hasattr(batch_node, key):
+                setattr(batch_node, key, value)
+            else:
+                log.warning(
+                    f"Attribute {key} not found on batch node {node_name}"
+                )
 
     # link nodes to each other
     for link in batch_links:
         _from_n, _to_n = link["from_node"], link["to_node"]
 
-        # check if all linking nodes are available
-        if not all([
-            all_batch_nodes.get(_from_n["id"]),
-            all_batch_nodes.get(_to_n["id"])
-        ]):
-            continue
+        if(
+            all_batch_nodes.get(_from_n["id"])
+            and all_batch_nodes.get(_to_n["id"])
+        ):
+            batch.connect_nodes(
+                all_batch_nodes[_from_n["id"]], _from_n["connector"],
+                all_batch_nodes[_to_n["id"]], _to_n["connector"]
+            )
+        else:
+            log.warning(
+                f"Failed to link node(s) {_from_n['id']} to {_to_n['id']}."
+            )
 
-        # link nodes in defined link
-        batch_group.connect_nodes(
-            all_batch_nodes[_from_n["id"]], _from_n["connector"],
-            all_batch_nodes[_to_n["id"]], _to_n["connector"]
-        )
-
-    # sort batch nodes
-    batch_group.organize()
-
+    batch.organize()  # sort batch nodes
     return all_batch_nodes
+
+
+def get_batch_from_workspace(
+    name: str,
+    workspace: Optional[flame.Workspace] = None
+) -> Optional[flame.PyBatch]:
+    """ Get batch group from name and workspace.
+    """
+    if workspace is None:
+        project = flame.project.current_project
+        workspace = project.current_workspace
+
+    desktop = workspace.desktop
+    for batchgroup in desktop.batch_groups:
+        if batchgroup.name.get_value() == name:
+            return batchgroup
+
+    return None

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -132,7 +132,7 @@ def edit_batch_group_content(
 
 def get_batch_from_workspace(
     name: str,
-    workspace: Optional[flame.Workspace] = None
+    workspace: Optional[flame.PyWorkspace] = None
 ) -> Optional[flame.PyBatch]:
     """ Get batch group from name and workspace.
     """

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -1,6 +1,5 @@
 from typing import Optional, List, Dict, Any
 
-import os
 import pathlib
 import json
 import tempfile

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -44,7 +44,7 @@ def update_batch(
     if name:
         batch.name = name
     if frame_start is not None:
-        batch.start_frame = frame_start
+        batch.start_frame = frame_start - handle_start
     if frame_duration is not None:
         frame_duration += handle_start + handle_end
         batch.duration = frame_duration

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -1,5 +1,10 @@
 from typing import Optional, List, Dict, Any
 
+import os
+import pathlib
+import json
+import tempfile
+
 from ayon_core.lib import Logger
 
 import flame
@@ -142,3 +147,81 @@ def get_batch_from_workspace(
             return batchgroup
 
     return None
+
+
+def save_batch_as_consolidated_json(
+    batch: flame.PyBatch,
+    filepath: str,
+    temporary_folder: Optional[str] = None,  # where flame run native export
+) -> str:
+    """ Export batch as a consolidated json file.
+    """
+    tmp = tempfile.TemporaryDirectory() if temporary_folder is None else None
+    tmp_dir = pathlib.Path(tmp.name if tmp else temporary_folder)
+
+    try:
+        bgroup_file = tmp_dir / f"{batch.name}.batch"
+        batch.save_setup(str(bgroup_file))
+
+        if not tmp_dir.is_dir():
+            raise RuntimeError(
+                f"Unable to save batchgroup to folder: {tmp_dir}."
+            )
+
+        # Concatenate all intermediary files as 1 single consolidated JSON.
+        json_output = {}
+        for file_path in tmp_dir.rglob("*"):
+            if file_path.is_file():
+                relative_path = file_path.relative_to(tmp_dir)
+                try:
+                    content = file_path.read_text(encoding="utf-8")
+                    json_output[str(relative_path)] = content
+                except Exception as error:
+                    raise RuntimeError(
+                        f"Could not encode file {file_path} as text: {error}"
+                    ) from error
+
+        with open(filepath, "w") as file_handler:
+            json.dump(json_output, file_handler, indent=4)
+
+    finally:
+        # Delete temporary directory if created.
+        if tmp is not None:
+            tmp.cleanup()
+
+    return filepath
+
+
+def load_batch_from_consolidated_json(
+    filepath: str,
+    temporary_folder: Optional[str] = None,
+) -> Optional[flame.PyBatch]:
+    """ Load a batch from a consolidated json file.
+    """
+    with open(filepath, "r", encoding="utf-8") as file_:
+        data = json.load(file_)
+
+    tmp = tempfile.TemporaryDirectory() if not temporary_folder else None
+    tmp_dir = pathlib.Path(tmp.name if tmp else temporary_folder)
+
+    try:
+        batch_file = None
+        for relative_file, content in data.items():
+            file_path = tmp_dir / relative_file
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text(content, encoding="utf-8")
+
+            if relative_file.endswith(".batch"):
+                batch_file = relative_file
+
+        if batch_file is None:
+            raise ValueError(
+                f"No valid batch found in consolidated json: {filepath}"
+            )
+
+        return flame.batch.load_setup(str(tmp_dir / batch_file))
+
+    finally:
+        # Delete temporary directory if created.
+        if tmp is not None:
+            tmp.cleanup()

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -159,7 +159,8 @@ def save_batch_as_consolidated_json(
     tmp_dir = pathlib.Path(tmp.name if tmp else temporary_folder)
 
     try:
-        bgroup_file = tmp_dir / f"{batch.name}.batch"
+        batch_name = batch.name.get_value()
+        bgroup_file = tmp_dir / f"{batch_name}.batch"
         batch.save_setup(str(bgroup_file))
 
         if not tmp_dir.is_dir():

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -193,6 +193,7 @@ def save_batch_as_consolidated_json(
 
 def load_batch_from_consolidated_json(
     filepath: str,
+    name: Optional[str] = None,
     temporary_folder: Optional[str] = None,
 ) -> Optional[flame.PyBatch]:
     """ Load a batch from a consolidated json file.
@@ -218,9 +219,15 @@ def load_batch_from_consolidated_json(
                 f"No valid batch found in consolidated json: {filepath}"
             )
 
-        return flame.batch.load_setup(str(tmp_dir / batch_file))
+        flame.batch.load_setup(str(tmp_dir / batch_file))
+
+        # Restore the batch group name from the provided name
+        # or use the .batch filename stem otherwise.
+        batch_name = name or pathlib.Path(batch_file).stem
+        flame.batch.name = batch_name
+
+        return flame.batch
 
     finally:
-        # Delete temporary directory if created.
         if tmp is not None:
             tmp.cleanup()

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -1,5 +1,6 @@
 from typing import Optional, List, Dict, Any
 
+import base64
 import pathlib
 import json
 import tempfile
@@ -169,17 +170,19 @@ def save_batch_as_consolidated_json(
             )
 
         # Concatenate all intermediary files as 1 single consolidated JSON.
+        # Binary files (e.g. .mx presets are not utf-8) are base64-encoded
+        # using a "__b64__:" prefix so we can deserialize them.
         json_output = {}
         for file_path in tmp_dir.rglob("*"):
             if file_path.is_file():
                 relative_path = file_path.relative_to(tmp_dir)
                 try:
                     content = file_path.read_text(encoding="utf-8")
-                    json_output[str(relative_path)] = content
-                except Exception as error:
-                    raise RuntimeError(
-                        f"Could not encode file {file_path} as text: {error}"
-                    ) from error
+                except (UnicodeDecodeError, ValueError):
+                    content = "__b64__:" + base64.b64encode(
+                        file_path.read_bytes()
+                    ).decode("ascii")
+                json_output[str(relative_path)] = content
 
         with open(filepath, "w") as file_handler:
             json.dump(json_output, file_handler, indent=4)
@@ -210,7 +213,10 @@ def load_batch_from_consolidated_json(
         for relative_file, content in data.items():
             file_path = tmp_dir / relative_file
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(content, encoding="utf-8")
+            if content.startswith("__b64__:"):
+                file_path.write_bytes(base64.b64decode(content[8:]))
+            else:
+                file_path.write_text(content, encoding="utf-8")
 
             if relative_file.endswith(".batch"):
                 batch_file = relative_file

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -340,7 +340,7 @@ def set_clip_data_marker(clip, data=None):
             f"data points toward {segment_data}."
         )
 
-    set_segment_data_marker(segment)
+    set_segment_data_marker(segment, data=data)
 
 
 def set_publish_attribute(segment, value):

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 import itertools
 import json
@@ -8,8 +6,7 @@ import pickle
 import re
 import sys
 import tempfile
-import traceback
-import xml.etree.cElementTree as cET
+
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
 from pprint import pformat
@@ -43,19 +40,21 @@ class CTX:
 class ValidationAggregator:
     failed_segments: list = field(default_factory=list)
 
-    def has_errors(self):
-        return len(self.failed_segments) > 0
+    def has_errors(self) -> bool:
+        return bool(self.failed_segments)
 
 
 @contextlib.contextmanager
 def io_preferences_file(klass, filepath, write=False):
+    # Create file if it doesn't exist.
     if not os.path.exists(filepath):
         with open(filepath, "w"):
             pass
 
     try:
         flag = "wb" if write else "rb"
-        yield open(filepath, flag)
+        with open(filepath, flag) as file_handler:
+            yield file_handler
 
     except (IOError, EOFError) as _error:
         klass.log.info("Unable to work with preferences `{}`: {}".format(
@@ -63,57 +62,8 @@ def io_preferences_file(klass, filepath, write=False):
 
 
 class FlameAppFramework(object):
-    # flameAppFramework class takes care of preferences
-
-    class prefs_dict(dict):
-
-        def __init__(self, master, name, **kwargs):
-            self.name = name
-            self.master = master
-            if not self.master.get(self.name):
-                self.master[self.name] = {}
-            self.master[self.name].__init__()
-
-        def __getitem__(self, k):
-            return self.master[self.name].__getitem__(k)
-
-        def __setitem__(self, k, v):
-            return self.master[self.name].__setitem__(k, v)
-
-        def __delitem__(self, k):
-            return self.master[self.name].__delitem__(k)
-
-        def get(self, k, default=None):
-            return self.master[self.name].get(k, default)
-
-        def setdefault(self, k, default=None):
-            return self.master[self.name].setdefault(k, default)
-
-        def pop(self, *args, **kwargs):
-            return self.master[self.name].pop(*args, **kwargs)
-
-        def update(self, mapping=(), **kwargs):
-            self.master[self.name].update(mapping, **kwargs)
-
-        def __contains__(self, k):
-            return self.master[self.name].__contains__(k)
-
-        def copy(self):  # don"t delegate w/ super - dict.copy() -> dict :(
-            return type(self)(self)
-
-        def keys(self):
-            return self.master[self.name].keys()
-
-        @classmethod
-        def fromkeys(cls, keys, v=None):
-            return cls.master[cls.name].fromkeys(keys, v)
-
-        def __repr__(self):
-            return "{0}({1})".format(
-                type(self).__name__, self.master[self.name].__repr__())
-
-        def master_keys(self):
-            return self.master.keys()
+    """ Takes care of preferences.
+    """
 
     def __init__(self):
         self.name = self.__class__.__name__
@@ -186,78 +136,42 @@ class FlameAppFramework(object):
 
         return (prefs_file_path, prefs_user_file_path, prefs_global_file_path)
 
-    def load_prefs(self):
 
-        (proj_pref_path, user_pref_path,
-         glob_pref_path) = self.get_pref_file_paths()
-
-        # make directories if not exists
+    def _process_prefs(self, save: bool = False):
+        # make sure the preference folder is available
         try:
             os.makedirs(self.prefs_folder, exist_ok=True)
-        except Exception as err:
+        except Exception:
             self.log.error(
-                f"Unable to create folder {self.prefs_folder}")
-            raise err
+                "Unable to create folder %s",
+                self.prefs_folder
+            )
+            return False
 
-        with io_preferences_file(self, proj_pref_path) as prefs_file:
-            self.prefs = pickle.load(prefs_file)
-            self.log.info(
-                "Project - preferences contents:\n{}".format(
-                    pformat(self.prefs)
-                ))
+        # Read or write the prefs in each files.
+        for attr, path in zip(
+            (self.prefs, self.prefs_user, self.prefs_global),
+            self.get_pref_file_paths(),
+        ):
+            with io_preferences_file(self, path, True) as prefs_file:
+                if save:
+                    pickle.dump(attr, prefs_file)
+                else:
+                    attr.clear()
+                    attr.update(pickle.load(prefs_file))
 
-        with io_preferences_file(self, user_pref_path) as prefs_file:
-            self.prefs_user = pickle.load(prefs_file)
-            self.log.info(
-                "User - preferences contents:\n{}".format(
-                    pformat(self.prefs_user)
-                ))
-
-        with io_preferences_file(self, glob_pref_path) as prefs_file:
-            self.prefs_global = pickle.load(prefs_file)
-            self.log.info(
-                "Global - preferences contents:\n{}".format(
-                    pformat(self.prefs_global)
-                ))
+                self.log.info(
+                    "Preferences contents:\n%s",
+                    pformat(attr),
+                )
 
         return True
 
-    def save_prefs(self):
-        # make sure the preference folder is available
-        if not os.path.isdir(self.prefs_folder):
-            try:
-                os.makedirs(self.prefs_folder)
-            except Exception:
-                self.log.info("Unable to create folder {}".format(
-                    self.prefs_folder))
-                return False
+    def load_prefs(self) -> bool:
+        return self._process_prefs(save=False)
 
-        # get all pref file paths
-        (proj_pref_path, user_pref_path,
-         glob_pref_path) = self.get_pref_file_paths()
-
-        with io_preferences_file(self, proj_pref_path, True) as prefs_file:
-            pickle.dump(self.prefs, prefs_file)
-            self.log.info(
-                "Project - preferences contents:\n{}".format(
-                    pformat(self.prefs)
-                ))
-
-        with io_preferences_file(self, user_pref_path, True) as prefs_file:
-            pickle.dump(self.prefs_user, prefs_file)
-            self.log.info(
-                "User - preferences contents:\n{}".format(
-                    pformat(self.prefs_user)
-                ))
-
-        with io_preferences_file(self, glob_pref_path, True) as prefs_file:
-            pickle.dump(self.prefs_global, prefs_file)
-            self.log.info(
-                "Global - preferences contents:\n{}".format(
-                    pformat(self.prefs_global)
-                ))
-
-        return True
+    def save_prefs(self) -> bool:
+        return self._process_prefs(save=True)
 
 
 def get_current_project():
@@ -296,54 +210,40 @@ def rescan_hooks():
     import flame
     try:
         flame.execute_shortcut("Rescan Python Hooks")
-    except Exception:
-        pass
+    except Exception as error:
+        log.warning(
+            "Could not rescan Python hooks: %s" % error
+        )
 
 
-def get_metadata(project_name, _log=None):
-    # TODO: can be replaced by MediaInfoFile class method
+def get_metadata(project_name, _log=None) -> str:
     from adsk.libwiretapPythonClientAPI import (
         WireTapClient,
         WireTapServerHandle,
         WireTapNodeHandle,
         WireTapStr
     )
+    _log = _log or log
+    client = WireTapClient()
+    policy = WireTapStr()
 
-    class GetProjectColorPolicy(object):
-        def __init__(self, host_name=None, _log=None):
-            # Create a connection to the Backburner manager using the Wiretap
-            # python API.
-            #
-            self.log = _log or log
-            self.host_name = host_name or "localhost"
-            self._wiretap_client = WireTapClient()
-            if not self._wiretap_client.init():
-                raise Exception("Could not initialize Wiretap Client")
-            self._server = WireTapServerHandle(
-                "{}:IFFFS".format(self.host_name))
+    if not client.init():
+        raise Exception("Could not initialize Wiretap Client")
 
-        def process(self, project_name):
-            policy_node_handle = WireTapNodeHandle(
-                self._server,
-                "/projects/{}/syncolor/policy".format(project_name)
+    server = WireTapServerHandle("localhost:IFFFS")
+    node = WireTapNodeHandle(
+        server,
+        f"/projects/{project_name}/syncolor/policy"
+    )
+    _log.info(node)
+    if not node.getNodeTypeStr(policy):
+        _log.warning(
+            "Could not retrieve policy of '%s': %s" % (
+                node.getNodeId().id(),
+                node.lastError()
             )
-            self.log.info(policy_node_handle)
-
-            policy = WireTapStr()
-            if not policy_node_handle.getNodeTypeStr(policy):
-                self.log.warning(
-                    "Could not retrieve policy of '%s': %s" % (
-                        policy_node_handle.getNodeId().id(),
-                        policy_node_handle.lastError()
-                    )
-                )
-
-            return policy.c_str()
-
-    policy_wiretap = GetProjectColorPolicy(_log=_log)
-    return policy_wiretap.process(project_name)
-
-
+        )
+    return policy.c_str()
 
 
 def get_segment_data_marker(segment, with_marker=None):
@@ -364,8 +264,10 @@ def get_segment_data_marker(segment, with_marker=None):
         color = marker.colour.get_value()
         name = marker.name.get_value()
 
-        if (name == MARKER_NAME) and (
-                color == COLOR_MAP[MARKER_COLOR]):
+        if (
+            name == MARKER_NAME
+            and color == COLOR_MAP[MARKER_COLOR]
+        ):
             if not with_marker:
                 return json.loads(comment)
             else:
@@ -438,20 +340,7 @@ def set_clip_data_marker(clip, data=None):
             f"data points toward {segment_data}."
         )
 
-    marker_data = get_segment_data_marker(segment, True)
-
-    if marker_data:
-        # get available AYON tag if any
-        marker, tag_data = marker_data
-        # update tag data with new data
-        tag_data.update(data)
-        # update marker with tag data
-        marker.comment = json.dumps(tag_data)
-    else:
-        # update tag data with new data
-        marker = create_segment_data_marker(segment)
-        # add tag data to marker's comment
-        marker.comment = json.dumps(data)
+    set_segment_data_marker(segment)
 
 
 def set_publish_attribute(segment, value):
@@ -522,7 +411,6 @@ def create_clip_data_marker(clip):
     """
     # get duration of segment
     duration = clip.duration.frame
-    print(duration)
     # calculate start frame of the new marker
     start_frame = int(clip.start_frame) + int(duration / 2)
     # create marker
@@ -574,8 +462,7 @@ def maintained_segment_selection(sequence):
         >>> with maintained_segment_selection(sequence) as selected_segments:
         ...     for segment in selected_segments:
         ...         segment.selected = False
-        >>> print(segment.selected)
-        True
+        >>> assert(segment.selected)
     """
     selected_segments = get_sequence_segments(sequence, True)
     try:
@@ -601,7 +488,6 @@ def reset_segment_selection(sequence):
 
 
 def _get_shot_tokens_values(clip, tokens):
-    old_value = None
     output = {}
 
     if not clip.shot_name:
@@ -673,18 +559,13 @@ def get_segment_attributes(
             validation_aggregator.failed_segments.append(segment)
 
     # head and tail with forward compatibility
-    if segment.head:
-        # `infinite` can be also returned
-        if isinstance(segment.head, str):
-            clip_data["segment_head"] = 0
-        else:
-            clip_data["segment_head"] = int(segment.head)
-    if segment.tail:
-        # `infinite` can be also returned
-        if isinstance(segment.tail, str):
-            clip_data["segment_tail"] = 0
-        else:
-            clip_data["segment_tail"] = int(segment.tail)
+    for key in ("head", "tail"):
+        value = getattr(segment, key)
+        if value:
+            clip_data[f"segment_{key}"] = (
+                0 if isinstance(value, str)
+                else int(value)
+            )
 
     # add all available shot tokens
     shot_tokens = _get_shot_tokens_values(segment, [
@@ -1331,7 +1212,7 @@ class MediaInfoFile(object):
         """
         try:
             # save it as new file
-            tree = cET.ElementTree(xml_element_data)
+            tree = ET.ElementTree(xml_element_data)
             tree.write(
                 fpath, xml_declaration=True,
                 method="xml", encoding="UTF-8"
@@ -1397,11 +1278,10 @@ class TimeEffectMetadata(object):
     def _get_attributes_from_xml(self, tmp_path):
         with open(tmp_path, "r") as tw_setup_file:
             tw_setup_string = tw_setup_file.read()
-            tw_setup_file.close()
 
         tw_setup_xml = ET.fromstring(tw_setup_string)
         tw_setup = self._dictify(tw_setup_xml)
-        # pprint(tw_setup)
+
         try:
             tw_setup_state = tw_setup["Setup"]["State"][0]
             mode = int(
@@ -1451,9 +1331,8 @@ class TimeEffectMetadata(object):
                         )
                     }
                 }
-        except Exception:
-            lines = traceback.format_exception(*sys.exc_info())
-            self.log.error("\n".join(lines))
+        except Exception as error:
+            self.log.error(error, exc_info=True)
             return None, {}
 
         return tw_setup_string, r_data

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -889,15 +889,6 @@ def get_clip_segment(flame_clip):
     return segments[0]
 
 
-def get_batch_group_from_desktop(name):
-    project = get_current_project()
-    project_desktop = project.current_workspace.desktop
-
-    for bgroup in project_desktop.batch_groups:
-        if bgroup.name.get_value() in name:
-            return bgroup
-
-
 class MediaInfoFile(object):
     """Class to get media info file clip data
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -153,7 +153,7 @@ class FlameAppFramework(object):
             (self.prefs, self.prefs_user, self.prefs_global),
             self.get_pref_file_paths(),
         ):
-            with io_preferences_file(self, path, True) as prefs_file:
+            with io_preferences_file(self, path, write=save) as prefs_file:
                 if save:
                     pickle.dump(attr, prefs_file)
                 else:

--- a/client/ayon_flame/api/menu.py
+++ b/client/ayon_flame/api/menu.py
@@ -239,6 +239,56 @@ class FlameMenuTimeline(_FlameMenuApp):
             self.log.info('Rescan Python Hooks')
 
 
+class FlameMenuBatch(_FlameMenuApp):
+
+    def __init__(self, framework):
+        _FlameMenuApp.__init__(self, framework)
+
+    def build_menu(self):
+        if not self.flame:
+            return []
+
+        menu = deepcopy(self.menu)
+        menu['actions'].append(
+            {
+                "name": "1 - Create...",
+                "execute": lambda x: callback_selection(
+                    x,
+                    host_tools.show_publisher(
+                        tab="create", parent=_get_main_window()
+                    ),
+                    context="FlameMenuBatch"
+                ),
+            }
+        )
+        menu["actions"].append(
+            {
+                "name": "2 - Publish...",
+                "execute": lambda x: callback_selection(
+                    x,
+                    host_tools.show_publisher(
+                        tab="publish", parent=_get_main_window()
+                    ),
+                    context="FlameMenuBatch"
+                ),
+            }
+        )
+        menu['actions'].append({
+            "name": "3 - Load...",
+            "execute": lambda x: callback_selection(
+                x,
+                self.tools_helper.show_loader,
+                context="FlameMenuBatch"
+            )
+        })
+        menu['actions'].append({
+            "name": "4 - Library...",
+            "execute": lambda x: self.tools_helper.show_library_loader()
+        })
+
+        return menu
+
+
 class FlameMenuUniversal(_FlameMenuApp):
 
     # flameMenuProjectconnect app takes care of the preferences dialog as well

--- a/client/ayon_flame/api/menu.py
+++ b/client/ayon_flame/api/menu.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from pprint import pformat
 
@@ -6,25 +7,10 @@ from qtpy import QtWidgets
 from ayon_core.pipeline import get_current_project_name
 from ayon_core.tools.utils import host_tools
 
-menu_group_name = 'AYON'
 
-default_flame_export_presets = {
-    'Publish': {
-        'PresetVisibility': 2,
-        'PresetType': 0,
-        'PresetFile': 'OpenEXR/OpenEXR (16-bit fp PIZ).xml'
-    },
-    'Preview': {
-        'PresetVisibility': 3,
-        'PresetType': 2,
-        'PresetFile': 'Generate Preview.xml'
-    },
-    'Thumbnail': {
-        'PresetVisibility': 3,
-        'PresetType': 0,
-        'PresetFile': 'Generate Thumbnail.xml'
-    }
-}
+logger = logging.getLogger(__name__)
+
+menu_group_name = 'AYON'
 
 
 def callback_selection(
@@ -35,7 +21,7 @@ def callback_selection(
     import ayon_flame.api as ayfapi
     ayfapi.CTX.selection = selection
     ayfapi.CTX.context = context
-    print("Hook Selection: \n\t{}".format(
+    logger.debug("Hook Selection: \n\t{}".format(
         pformat({
             index: (type(item), item.name)
             for index, item in enumerate(ayfapi.CTX.selection)})
@@ -66,7 +52,6 @@ class _FlameMenuApp(object):
         self.framework = framework
         self.log = framework.log
         self.menu_group_name = menu_group_name
-        self.dynamic_menu_data = {}
 
         # flame module is only available when a
         # flame project is loaded and initialized
@@ -74,17 +59,19 @@ class _FlameMenuApp(object):
         try:
             import flame
             self.flame = flame
+            self.flame_project_name = flame.project.current_project.name
+
         except ImportError:
             self.flame = None
+            self.flame_project_name = None
 
-        self.flame_project_name = flame.project.current_project.name
-        self.prefs = self.framework.prefs_dict(self.framework.prefs, self.name)
-        self.prefs_user = self.framework.prefs_dict(
-            self.framework.prefs_user, self.name)
-        self.prefs_global = self.framework.prefs_dict(
-            self.framework.prefs_global, self.name)
+        self.prefs = self.framework.prefs.setdefault(self.name, {})
+        self.prefs_user = self.framework.prefs_user.setdefault(self.name, {})
+        self.prefs_global = self.framework.prefs_global.setdefault(
+            self.name,
+            {}
+        )
 
-        self.mbox = QtWidgets.QMessageBox()
         project_name = get_current_project_name()
         self.menu = {
             "actions": [
@@ -101,7 +88,7 @@ class _FlameMenuApp(object):
 
     def __getattr__(self, name):
         def method(*args, **kwargs):
-            print('calling %s' % name)
+            logger.debug('calling %s' % name)
         return method
 
     def rescan(self, *args, **kwargs):
@@ -116,20 +103,13 @@ class _FlameMenuApp(object):
             self.flame.execute_shortcut('Rescan Python Hooks')
             self.log.info('Rescan Python Hooks')
 
+    def refresh(self, *args, **kwargs):
+        self.rescan()
+
 
 class FlameMenuProjectConnect(_FlameMenuApp):
-
-    # flameMenuProjectconnect app takes care of the preferences dialog as well
-
-    def __init__(self, framework):
-        _FlameMenuApp.__init__(self, framework)
-
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            project = self.dynamic_menu_data.get(name)
-            if project:
-                self.link_project(project)
-        return method
+    """ Takes care of the preferences dialog as well.
+    """
 
     def build_menu(self):
         if not self.flame:
@@ -148,35 +128,10 @@ class FlameMenuProjectConnect(_FlameMenuApp):
 
         return menu
 
-    def refresh(self, *args, **kwargs):
-        self.rescan()
-
-    def rescan(self, *args, **kwargs):
-        if not self.flame:
-            try:
-                import flame
-                self.flame = flame
-            except ImportError:
-                self.flame = None
-
-        if self.flame:
-            self.flame.execute_shortcut('Rescan Python Hooks')
-            self.log.info('Rescan Python Hooks')
-
 
 class FlameMenuTimeline(_FlameMenuApp):
-
-    # flameMenuProjectconnect app takes care of the preferences dialog as well
-
-    def __init__(self, framework):
-        _FlameMenuApp.__init__(self, framework)
-
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            project = self.dynamic_menu_data.get(name)
-            if project:
-                self.link_project(project)
-        return method
+    """ Menu that appears in the timeline context.
+    """
 
     def build_menu(self):
         if not self.flame:
@@ -212,6 +167,7 @@ class FlameMenuTimeline(_FlameMenuApp):
             "name": "3 - Load...",
             "execute": lambda x: self.tools_helper.show_loader()
         })
+        # TODO: enable once scene inventory is ready
         # menu['actions'].append({
         #     "name": "Manage...",
         #     "execute": lambda x: self.tools_helper.show_scene_inventory()
@@ -223,35 +179,10 @@ class FlameMenuTimeline(_FlameMenuApp):
 
         return menu
 
-    def refresh(self, *args, **kwargs):
-        self.rescan()
-
-    def rescan(self, *args, **kwargs):
-        if not self.flame:
-            try:
-                import flame
-                self.flame = flame
-            except ImportError:
-                self.flame = None
-
-        if self.flame:
-            self.flame.execute_shortcut('Rescan Python Hooks')
-            self.log.info('Rescan Python Hooks')
-
 
 class FlameMenuUniversal(_FlameMenuApp):
-
-    # flameMenuProjectconnect app takes care of the preferences dialog as well
-
-    def __init__(self, framework):
-        _FlameMenuApp.__init__(self, framework)
-
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            project = self.dynamic_menu_data.get(name)
-            if project:
-                self.link_project(project)
-        return method
+    """ Menu that appears in the universal context.
+    """
 
     def build_menu(self):
         if not self.flame:
@@ -296,18 +227,3 @@ class FlameMenuUniversal(_FlameMenuApp):
         })
 
         return menu
-
-    def refresh(self, *args, **kwargs):
-        self.rescan()
-
-    def rescan(self, *args, **kwargs):
-        if not self.flame:
-            try:
-                import flame
-                self.flame = flame
-            except ImportError:
-                self.flame = None
-
-        if self.flame:
-            self.flame.execute_shortcut('Rescan Python Hooks')
-            self.log.info('Rescan Python Hooks')

--- a/client/ayon_flame/api/pipeline.py
+++ b/client/ayon_flame/api/pipeline.py
@@ -46,15 +46,13 @@ class FlameHost(HostBase, ILoadHost, IPublishHost):
         return ls()
 
     def install(self):
-        """Installing all requirements for Nuke host"""
+        """Installing all requirements for Flame host"""
         install()
 
     def get_context_data(self):
-        # TODO: find a way to implement this
         return deepcopy(self._publish_context_data)
 
     def update_context_data(self, data, changes):
-        # TODO: find a way to implement this
         self._publish_context_data = deepcopy(data)
 
 
@@ -64,9 +62,6 @@ def install():
     register_loader_plugin_path(LOAD_PATH)
     register_creator_plugin_path(CREATE_PATH)
     log.info("AYON Flame plug-ins registered ...")
-
-    # register callback for switching publishable
-    pyblish.register_callback("instanceToggled", on_pyblish_instance_toggled)
 
     log.info("AYON Flame host installed ...")
 
@@ -78,9 +73,6 @@ def uninstall():
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     deregister_loader_plugin_path(LOAD_PATH)
     deregister_creator_plugin_path(CREATE_PATH)
-
-    # register callback for switching publishable
-    pyblish.deregister_callback("instanceToggled", on_pyblish_instance_toggled)
 
     log.info("AYON Flame host uninstalled ...")
 
@@ -102,10 +94,8 @@ def containerise(flame_clip_segment,
     }
 
     if data:
-        for k, v in data.items():
-            data_imprint[k] = v
+        data_imprint.update(data)
 
-    # TODO: implement also openClip loaded data
     # timeline item imprinted data
     set_segment_data_marker(flame_clip_segment, data_imprint)
 
@@ -121,38 +111,23 @@ def ls():
 def parse_container(tl_segment, validate=True):
     """Return container data from timeline_item's AYON tag.
     """
-    # TODO: parse_container
-    pass
+    log.debug("TODO: parse_container")
 
 
 def update_container(tl_segment, data=None):
     """Update container data to input timeline_item's AYON tag.
     """
-    # TODO: update_container
-    pass
-
-
-def on_pyblish_instance_toggled(instance, old_value, new_value):
-    """Toggle node passthrough states on instance toggles."""
-
-    log.info("instance toggle: {}, old_value: {}, new_value:{} ".format(
-        instance, old_value, new_value))
-
-    # # Whether instances should be passthrough based on new value
-    # timeline_item = instance.data["item"]
-    # set_publish_attribute(timeline_item, new_value)
+    log.debug("TODO: update_container")
 
 
 def remove_instance(instance):
     """Remove instance marker from track item."""
-    # TODO: remove_instance
-    pass
+    log.debug("TODO: remove_instance")
 
 
 def list_instances():
     """List all created instances from current workfile."""
-    # TODO: list_instances
-    pass
+    log.debug("TODO: list_instances")
 
 
 def imprint(item, data=None):
@@ -180,8 +155,6 @@ def imprint(item, data=None):
         set_clip_data_marker(item, data)
     else:
         raise TypeError("Unsupported item type: {}".format(type(item)))
-
-
 
 
 @contextlib.contextmanager

--- a/client/ayon_flame/api/pipeline.py
+++ b/client/ayon_flame/api/pipeline.py
@@ -22,7 +22,6 @@ from ayon_flame import FLAME_ADDON_ROOT
 from .lib import (
     get_current_sequence,
     maintained_segment_selection,
-    reset_segment_selection,
     set_clip_data_marker,
     set_segment_data_marker,
 )

--- a/client/ayon_flame/api/pipeline.py
+++ b/client/ayon_flame/api/pipeline.py
@@ -39,14 +39,15 @@ log = Logger.get_logger(__name__)
 class FlameHost(HostBase, ILoadHost, IPublishHost):
     name = "flame"
 
-    # object variables
-    _publish_context_data = {}
+    def __init__(self):
+        super().__init__()
+        self._publish_context_data = {}
 
     def get_containers(self):
         return ls()
 
     def install(self):
-        """Installing all requirements for Flame host"""
+        """Install all requirements for Flame host"""
         install()
 
     def get_context_data(self):
@@ -61,20 +62,19 @@ def install():
     pyblish.register_plugin_path(PUBLISH_PATH)
     register_loader_plugin_path(LOAD_PATH)
     register_creator_plugin_path(CREATE_PATH)
-    log.info("AYON Flame plug-ins registered ...")
-
-    log.info("AYON Flame host installed ...")
+    log.info("AYON Flame plug-ins registered.")
+    log.info("AYON Flame host installed.")
 
 
 def uninstall():
     pyblish.deregister_host("flame")
 
-    log.info("Deregistering Flame plug-ins..")
+    log.info("Deregistering Flame plug-ins.")
     pyblish.deregister_plugin_path(PUBLISH_PATH)
     deregister_loader_plugin_path(LOAD_PATH)
     deregister_creator_plugin_path(CREATE_PATH)
 
-    log.info("AYON Flame host uninstalled ...")
+    log.info("AYON Flame host uninstalled.")
 
 
 def containerise(flame_clip_segment,
@@ -83,7 +83,8 @@ def containerise(flame_clip_segment,
                  context,
                  loader=None,
                  data=None):
-
+    """ Containerise a flame clip segment.
+    """
     data_imprint = {
         "schema": "ayon:container-3.0",
         "id": AYON_CONTAINER_ID,
@@ -105,7 +106,7 @@ def containerise(flame_clip_segment,
 def ls():
     """List available containers.
     """
-    return []
+    return []  # TODO implement this from metadata
 
 
 def parse_container(tl_segment, validate=True):
@@ -137,8 +138,8 @@ def imprint(item, data=None):
     Also including publish attribute into tag.
 
     Arguments:
-        item (flame.PySegment | flame.PyClip)): flame api object
-        data (dict): Any data which needst to be imprinted
+        item (flame.PySegment | flame.PyClip): flame api object
+        data (dict): Any data which needs to be imprinted
 
     Examples:
         data = {
@@ -160,17 +161,6 @@ def imprint(item, data=None):
 @contextlib.contextmanager
 def maintained_selection():
     from .lib import CTX
-
-    # check if segment is selected
-    if isinstance(CTX.selection[0], flame.PySegment):
-        sequence = get_current_sequence(CTX.selection)
-
-        try:
-            with maintained_segment_selection(sequence) as selected:
-                yield
-        finally:
-            # reset all selected clips
-            reset_segment_selection(sequence)
-            # select only original selection of segments
-            for segment in selected:
-                segment.selected = True
+    sequence = get_current_sequence(CTX.selection)
+    with maintained_segment_selection(sequence):
+        yield

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -1,9 +1,8 @@
 import logging
 import os
 import re
-import logging
 import shutil
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from copy import deepcopy
 from xml.etree import ElementTree as ET
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -15,6 +15,10 @@ import flame
 import ayon_api
 
 from ayon_core.lib import Logger, StringTemplate
+from ayon_core.lib.transcoding import (
+    VIDEO_EXTENSIONS,
+    IMAGE_EXTENSIONS
+)
 from ayon_core.pipeline import (
     LoaderPlugin,
     Creator,
@@ -566,6 +570,14 @@ class ClipLoader(LoaderPlugin):
     """
     log = log
 
+    product_base_types = {
+        "render2d", "source", "plate", "render", "review"
+    }
+    representations = {"*"}
+    extensions = set(
+        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
+    )
+
     options = [
         qargparse.Boolean(
             "handles",
@@ -665,78 +677,93 @@ class ClipLoader(LoaderPlugin):
 
         return native_name
 
-    def _get_formatting_data(self, context, options):
-        return deepcopy(context["representation"]["context"])
+    def _get_clip_name_format_data(self, context, _) -> dict[str, str]:
+        """ Get formatting data for the clip name template.
+        """
+        format_data = deepcopy(context["representation"]["context"])
+        folder_entity = context["folder"]
+        product_entity = context["product"]
+        format_data.update({
+            "asset": folder_entity["name"],
+            "folder": {
+                "name": folder_entity["name"],
+            },
+            "subset": product_entity["name"],
+            "family": product_entity["productType"],
+            "product": {
+                "name": product_entity["name"],
+                "type": product_entity["productType"],
+                "basetype": product_entity["productBaseType"],
+            }
+        })
+
+        if not format_data.get("output"):
+            format_data["output"] = context["representation"]
+
+        return format_data
 
     def load(self, context, name, namespace, options):
-        # get flame objects
+        """
+        From a specific clip representation, load it with all of
+        its versions, connecting to Flame native OpenClip version support.
+        """
         fproject = flame.project.current_project
         self.fpd = fproject.current_workspace.desktop
 
-        # load clip to timeline and get main variables
-        version_entity = context["version"]
-        representation_name = context["representation"]["name"]
-        project_name = context["project"]["name"]
-
-        repre_context = deepcopy(
-            context["representation"]["context"]
-        )
-        if not repre_context.get("output"):
-            repre_context["output"] = repre_context["representation"]
-
+        # Build clip name from current clip,
+        # using settings template and representation context.
         clip_name = StringTemplate(self.clip_name_template).format(
-            repre_context
+            self._get_clip_name_format_data(context, options)
         )
 
-        # create workfile path
+        # Flame OpenClip is a file-based format,
+        # prepare clip file in work directory.
         workfile_dir = os.environ["AYON_WORKDIR"]
-        openclip_dir = os.path.join(
-            workfile_dir, clip_name
-        )
+        openclip_dir = os.path.join(workfile_dir, clip_name)
         openclip_path = os.path.join(
             openclip_dir, clip_name + ".clip"
         )
-        if not os.path.exists(openclip_dir):
-            os.makedirs(openclip_dir)
+        os.makedirs(openclip_dir, exist_ok=True)
 
-        clip_solver = OpenClipSolver(
-            openclip_path, self.layer_rename_patterns
-        )
-        rename_clip = clip_solver.out_clip_data is None
-        if not version_entity["taskId"]:
-            all_versions = [version_entity]
-        else:
-            all_versions = ayon_api.get_versions(
+        # Find all versions for the clip.
+        project_name = context["project"]["name"]
+        product_id =  context["version"]["productId"]
+        all_versions = list(
+            ayon_api.get_versions(
                 project_name,
-                product_ids=[version_entity["productId"]],
-                task_ids=[version_entity["taskId"]],
+                product_ids=[product_id],
             )
+        )
 
-        repres_by_version_id = {
-            version["id"]: None
-            for version in all_versions
-        }
+        # Find all representations per version.
+        repres_by_version_id = {}
         for repre_entity in ayon_api.get_representations(
              project_name,
-             representation_names={representation_name},
-             version_ids=set(repres_by_version_id),
+             representation_names={context["representation"]["name"]},
+             version_ids=[version["id"] for version in all_versions],
          ):
-             version_id = repre_entity["versionId"]
-             repres_by_version_id[version_id] = repre_entity
+             repre_version_id = repre_entity["versionId"]
+             repres_by_version_id[repre_version_id] = repre_entity
 
-        for version in all_versions:
-            representation = repres_by_version_id[version["id"]]
+        # Prepare OpenClip object.
+        clip_solver = OpenClipSolver(
+            openclip_path,
+            self.layer_rename_patterns
+        )
+        # out_clip_data is None: create new clip = allow rename
+        rename_clip = clip_solver.out_clip_data is None
 
+        # Resolve each version as new OpenClip feed.
+        for version_id, representation in repres_by_version_id.items():
+            version = next(v for v in all_versions if v["id"] == version_id)
             version_context = deepcopy(context)
             version_context["version"] = version
             version_context["representation"] = representation
-
             version_name = version["name"]
             colorspace = self.get_colorspace(version_context)
 
-            layer_rename_template = self.layer_rename_template
-
             # in case output is not in context replace key to representation
+            layer_rename_template = self.layer_rename_template
             if not representation["context"].get("output"):
                 layer_rename_template = self.layer_rename_template.replace(
                     "output", "representation"
@@ -757,37 +784,18 @@ class ClipLoader(LoaderPlugin):
                 layer_rename_template,
             )
 
+        version_entity = context["version"]
         clip_solver.set_current_version(
             f"v{version_entity['version']:03}"
         )
-
         clip_solver.write()
 
         # prepare Reel group in actual desktop
-        opc = self._get_clip(
-            clip_name,
-            openclip_path
-        )
-
-        if len(all_versions) == 1 and rename_clip:
+        opc = self._get_clip(clip_name, openclip_path)
+        if rename_clip:
             opc.name = f"{clip_name} [v{version_entity['version']:03}]"
         else:
             opc.name = clip_name
-
-        if not version_entity["taskId"]:
-            flame.messages.show_in_dialog(
-                "Import Warning",
-                (
-                    "Version doesn't have set task."
-                    "\nUnable to import any other versions alongside"
-                    " the current selection."
-                    "\nThis may result in unordered versions within the"
-                    " clip. Deleting the clip and reloading it will resolve"
-                    " this issue."
-                ),
-                "warning",
-                ["OK"],
-            )
 
         return opc
 
@@ -802,12 +810,30 @@ class ClipLoader(LoaderPlugin):
         return created_clips.pop()
 
     def _get_reel(self):
-        raise NotImplementedError()
+        """ Retrieve/Create expected reel for current clip.
+        """
+        raise NotImplementedError(
+            "To be implemented by public loader subclass."
+        )
+
+    def update(self, container, context):
+        """ AYON native version management.
+        """
+        raise NotImplementedError(
+            "Version management rely on Flame "
+            "native implementation through OpenClip."
+        )
+
+    def remove(self, container):
+        """ AYON native version management.
+        """
+        raise NotImplementedError(
+            "Version management rely on Flame "
+            "native implementation through OpenClip."
+        )
 
 
 class OpenClipSolver:
-
-    log = log
 
     def __init__(
         self,
@@ -820,8 +846,7 @@ class OpenClipSolver:
         self.layer_rename_patterns = layer_rename_patterns
 
         # replace log if any
-        if logger:
-            self.log = logger
+        self.log = logger if logger else log
         self.out_clip_data = None
         if self._is_valid_tmp_file(self.out_file):
             self.out_clip_data = ET.parse(self.out_file).getroot()
@@ -1061,9 +1086,16 @@ class OpenClipSolver:
         )
 
     def set_current_version(self, version_name: str) -> None:
+        if self.out_clip_data is None:
+            raise ValueError(
+                "Cannot set current version: No clip data available"
+            )
+
+        # Adjust current version in xml versions slot.
         out_xml_versions_obj = self.out_clip_data.find("versions")
         out_xml_versions_obj.set("currentVersion", version_name)
 
+        # Adjust current version in xml feeds.
         for out_xml_track in self.out_clip_data.iter("track"):
             out_feeds = out_xml_track.find("feeds")
             for feed in out_feeds.iter("feed"):

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -561,12 +561,7 @@ class PublishableClip:
 
 # Loader plugin functions
 class ClipLoader(LoaderPlugin):
-    """A basic clip loader for Flame
-
-    This will implement the basic behavior for a loader to inherit from that
-    will containerize the reference and will implement the `remove` and
-    `update` logic.
-
+    """A basic clip loader for Flame leveraging native OpenClip API.
     """
     log = log
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -745,6 +745,18 @@ class ClipLoader(LoaderPlugin):
              repre_version_id = repre_entity["versionId"]
              repres_by_version_id[repre_version_id] = repre_entity
 
+        if not repres_by_version_id:
+            raise RuntimeError(
+                "Could not find any representations named '{}' for product "
+                "'{}' in project '{}' while preparing OpenClip feeds. "
+                "Current version id: '{}'. Checked {} version(s).".format(
+                    context["representation"]["name"],
+                    product_id,
+                    project_name,
+                    context["version"]["id"],
+                    len(all_versions),
+                )
+            )
         # Prepare OpenClip object.
         clip_solver = OpenClipSolver(
             openclip_path,

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -698,7 +698,7 @@ class ClipLoader(LoaderPlugin):
         })
 
         if not format_data.get("output"):
-            format_data["output"] = context["representation"]
+            format_data["output"] = format_data["representation"]
 
         return format_data
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -12,7 +12,7 @@ import flame
 
 import ayon_api
 
-from ayon_core.lib import Logger, StringTemplate
+from ayon_core.lib import StringTemplate
 from ayon_core.pipeline.create import CreatorError
 from ayon_core.pipeline import LoaderPlugin, HiddenCreator
 from ayon_core.pipeline import Creator
@@ -22,7 +22,7 @@ from ayon_core.pipeline.context_tools import get_current_project_settings
 from . import lib as flib
 
 
-log = Logger.get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 class HiddenFlameCreator(HiddenCreator):
@@ -46,7 +46,7 @@ class FlameCreator(Creator):
     settings_category = "flame"
 
     def __init__(self, *args, **kwargs):
-        super(Creator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.presets = get_current_project_settings()[
             "flame"]["create"].get(self.__class__.__name__, {})
         self.project = flib.get_current_project()
@@ -103,7 +103,6 @@ class PublishableClip:
     """
     vertical_clip_match = {}
     vertical_clip_used = {}
-    marker_data = {}
     types = {
         "shot": "shot",
         "folder": "folder",
@@ -144,6 +143,7 @@ class PublishableClip:
         self.product_type = product_type
         self.log = log
         self.pre_create_data = pre_create_data or {}
+        self.marker_data = {}
 
         # get main parent objects
         self.current_segment = segment
@@ -396,13 +396,10 @@ class PublishableClip:
         if not hero_track and self.vertical_sync:
             # driving layer is set as negative match
             for (hero_in, hero_out), hero_data in self.vertical_clip_match.items():  # noqa
-                """ Iterate over all clips in vertical sync match
-
-                If clip frame range is outside of hero clip frame range
-                then skip this clip and do not add to hierarchical shared
-                metadata to them.
-                """
-
+                # Iterate over all clips in vertical sync match
+                # If clip frame range is outside of hero clip frame range
+                # then skip this clip and do not add to hierarchical shared
+                # metadata to them.
                 if self.clip_in < hero_in or self.clip_out > hero_out:
                     continue
 
@@ -540,12 +537,10 @@ class PublishableClip:
         par_split = [(pattern.findall(t).pop(), t)
                      for t in self.hierarchy.split("/")]
 
-        for type, template in par_split:
-            parent = self._convert_to_entity(type, template)
+        for type_, template in par_split:
+            parent = self._convert_to_entity(type_, template)
             self.parents.append(parent)
 
-
-# Publishing plugin functions
 
 # Loader plugin functions
 class ClipLoader(LoaderPlugin):
@@ -592,14 +587,14 @@ class ClipLoader(LoaderPlugin):
         if not plugin_settings:
             return
 
-        print(">>> We have preset for {}".format(plugin_name))
+        log.debug(">>> We have preset for {}".format(plugin_name))
         for option, value in plugin_settings.items():
             if option == "enabled" and value is False:
-                print("  - is disabled by preset")
+                log.debug("  - is disabled by preset")
             elif option == "representations":
                 continue
             else:
-                print("  - setting `{}`: `{}`".format(option, value))
+                log.debug("  - setting `{}`: `{}`".format(option, value))
             setattr(cls, option, value)
 
     def get_colorspace(self, context):
@@ -688,8 +683,7 @@ class ClipLoader(LoaderPlugin):
         openclip_path = os.path.join(
             openclip_dir, clip_name + ".clip"
         )
-        if not os.path.exists(openclip_dir):
-            os.makedirs(openclip_dir)
+        os.makedirs(openclip_dir, exist_ok=True)
 
         clip_solver = OpenClipSolver(
             openclip_path, self.layer_rename_patterns
@@ -823,9 +817,9 @@ class OpenClipSolver:
         if os.path.isfile(file):
             # test also if file is not empty
             with open(file) as f:
-                lines = f.readlines()
+                lines = sum(1 for _ in f)
 
-            if len(lines) > 2:
+            if lines > 2:
                 return True
 
             # file is probably corrupted
@@ -1082,6 +1076,7 @@ class OpenClipSolver:
                 self.log.warning(
                     "Not appending file as it already is in .clip file")
                 return True
+        return False
 
     def _create_openclip_backup_file(self, file):
         if not os.path.isfile(file):
@@ -1104,8 +1099,8 @@ class OpenClipSolver:
     def _add_colorspace(self, feed_obj, profile_name):
         feed_storage_obj = feed_obj.find("storageFormat")
         feed_clr_obj = feed_storage_obj.find("colourSpace")
-        if feed_clr_obj is not None:
+        if feed_clr_obj is None:
             feed_clr_obj = ET.Element(
                 "colourSpace", {"type": "string"})
-            feed_clr_obj.text = profile_name
             feed_storage_obj.append(feed_clr_obj)
+        feed_clr_obj.text = profile_name

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -757,8 +757,6 @@ class ClipLoader(LoaderPlugin):
             openclip_path,
             self.layer_rename_patterns
         )
-        # out_clip_data is None: create new clip = allow rename
-        rename_clip = clip_solver.out_clip_data is None
 
         # Resolve each version as new OpenClip feed.
         for version_id, representation in repres_by_version_id.items():
@@ -783,13 +781,22 @@ class ClipLoader(LoaderPlugin):
             # prepare clip data from context ad send it to openClipLoader
             path = self.filepath_from_context(version_context)
 
-            clip_solver.add_feed(
-                path,
-                version_name,
-                colorspace,
-                representation["context"],
-                layer_rename_template,
-            )
+            try:
+                clip_solver.add_feed(
+                    path,
+                    version_name,
+                    colorspace,
+                    representation["context"],
+                    layer_rename_template,
+                )
+            except RuntimeError:
+                flame.messages.show_in_dialog(
+                    "Unsupported Input",
+                    f"Flame does not support incoming media path {path}",
+                    "warning",
+                    ["OK"],
+                )
+                return
 
         version_entity = context["version"]
         clip_solver.set_current_version(
@@ -799,10 +806,7 @@ class ClipLoader(LoaderPlugin):
 
         # prepare Reel group in actual desktop
         opc = self._get_clip(clip_name, openclip_path)
-        if rename_clip:
-            opc.name = f"{clip_name} [v{version_entity['version']:03}]"
-        else:
-            opc.name = clip_name
+        opc.name = clip_name
 
         return opc
 
@@ -880,7 +884,13 @@ class OpenClipSolver:
         context_data: dict[str, Any],
         layer_rename_template: str,
     ) -> None:
-        clip = flib.MediaInfoFile(path, self.log)
+        try:
+            clip = flib.MediaInfoFile(path, self.log)
+        except ET.ParseError as error:
+            self.log.error(f"Error adding feed: {error}")
+            raise RuntimeError(
+                f"Unsupported input media: {path}"
+            ) from error
 
         if self.out_clip_data is None:
             self.out_clip_data = clip.clip_data
@@ -967,7 +977,10 @@ class OpenClipSolver:
         layer_rename_template: str,
     ) -> None:
         layer_uid = xml_track_data.get("uid")
-        name_obj = xml_track_data.find("name")
+        name_obj = (
+            xml_track_data.find("name")
+            or xml_track_data.find("sourceName")
+        )
         layer_name = name_obj.text
 
         if (

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -979,12 +979,12 @@ class OpenClipSolver:
         layer_uid = xml_track_data.get("uid")
         name_obj = (
             xml_track_data.find("name")
-            or xml_track_data.find("sourceName")
         )
-        layer_name = name_obj.text
+        layer_name = name_obj.text if name_obj else None
 
         if (
             self.layer_rename_patterns
+            and layer_name
             and not any(
                 re.search(lp_.lower(), layer_name.lower())
                 for lp_ in self.layer_rename_patterns
@@ -1057,7 +1057,10 @@ class OpenClipSolver:
                 if clip.fps is not None:
                     tmp_feed_fps_obj = tmp_xml_feed.find(
                         "startTimecode/rate")
-                    tmp_feed_fps_obj.text = str(clip.fps)
+                    fps = clip.fps
+                    tmp_feed_fps_obj.text = (
+                        str(int(fps)) if fps == int(fps) else str(fps)
+                    )
 
                 # update start_frame from MediaInfoFile class
                 if clip.start_frame is not None:

--- a/client/ayon_flame/api/render_utils.py
+++ b/client/ayon_flame/api/render_utils.py
@@ -34,11 +34,6 @@ def export_clip(export_path, clip, preset_path, **kwargs):
 
     if kwargs.get("thumb_frame_number"):
         thumb_frame_number = kwargs["thumb_frame_number"]
-        # make sure it exists in kwargs
-        if not thumb_frame_number:
-            raise KeyError(
-                "Missing key `thumb_frame_number` in input kwargs")
-
         in_mark = int(thumb_frame_number)
         out_mark = int(thumb_frame_number) + 1
 
@@ -57,7 +52,7 @@ def export_clip(export_path, clip, preset_path, **kwargs):
         # export with exporter
         exporter.export(clip, preset_path, export_path)
     finally:
-        print('Exported: {} at {}-{}'.format(
+        log.debug('Exported: {} at {}-{}'.format(
             clip.name.get_value(),
             clip.in_mark,
             clip.out_mark
@@ -67,24 +62,20 @@ def export_clip(export_path, clip, preset_path, **kwargs):
 def get_preset_path_by_xml_name(xml_preset_name):
     def _search_path(root):
         output = []
-        for root, _dirs, files in os.walk(root):
+        for subroot, _dirs, files in os.walk(root):
             for f in files:
                 if f != xml_preset_name:
                     continue
-                file_path = os.path.join(root, f)
+                file_path = os.path.join(subroot, f)
                 output.append(file_path)
         return output
 
     def _validate_results(results):
-        if results and len(results) == 1:
-            return results.pop()
-        elif results and len(results) > 1:
-            print((
-                "More matching presets for `{}`: /n"
+        if results and len(results) > 1:
+            log.warning((
+                "More matching presets for `{}`: \n"
                 "{}").format(xml_preset_name, results))
-            return results.pop()
-        else:
-            return None
+        return results.pop() if results else None
 
     from .utils import (
         get_flame_install_root,
@@ -138,10 +129,10 @@ def modify_preset_file(xml_path, staging_dir, data):
         data (dict): data where key is xmlTag and value as string
 
     Returns:
-        str: _description_
+        str: path to modified preset file
     """
     # create temp path
-    dirname, basename = os.path.split(xml_path)
+    _, basename = os.path.split(xml_path)
     temp_path = os.path.join(staging_dir, basename)
 
     # change xml following data keys

--- a/client/ayon_flame/api/utils.py
+++ b/client/ayon_flame/api/utils.py
@@ -90,7 +90,7 @@ def _sync_utility_scripts(env=None):
                     )
                 )
 
-    # copy scripts into Resolve's utility scripts dir
+    # copy scripts into Flame's utility scripts dir
     for dirpath, scriptlist in scripts.items():
         # directory and scripts list
         for _script in scriptlist:
@@ -101,10 +101,7 @@ def _sync_utility_scripts(env=None):
 
             try:
                 if os.path.isdir(src):
-                    shutil.copytree(
-                        src, dst, symlinks=False,
-                        ignore=None, ignore_dangling_symlinks=False
-                    )
+                    shutil.copytree(src, dst)
                 else:
                     shutil.copy2(src, dst)
             except (PermissionError, FileExistsError) as msg:
@@ -140,4 +137,5 @@ def get_flame_version():
 
 
 def get_flame_install_root():
+    # Enforced Autodesk install path (no Windows support)
     return "/opt/Autodesk"

--- a/client/ayon_flame/api/workio.py
+++ b/client/ayon_flame/api/workio.py
@@ -1,37 +1,28 @@
 """Host API required Work Files tool"""
-
 import os
-from ayon_core.lib import Logger
-# from .. import (
-#     get_project_manager,
-#     get_current_project
-# )
 
-
-log = Logger.get_logger(__name__)
-
-exported_projet_ext = ".otoc"
+exported_project_ext = ".otoc"
 
 
 def file_extensions():
-    return [exported_projet_ext]
+    return [exported_project_ext]
 
 
 def has_unsaved_changes():
-    pass
+    raise NotImplementedError("Flame use native workfile management")
 
 
 def save_file(filepath):
-    pass
+    raise NotImplementedError("Flame use native workfile management")
 
 
 def open_file(filepath):
-    pass
+    raise NotImplementedError("Flame use native workfile management")
 
 
 def current_file():
-    pass
+    raise NotImplementedError("Flame use native workfile management")
 
 
 def work_root(session):
-    return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")
+    return os.path.normpath(session["AYON_WORKDIR"])

--- a/client/ayon_flame/api/workio.py
+++ b/client/ayon_flame/api/workio.py
@@ -9,19 +9,19 @@ def file_extensions():
 
 
 def has_unsaved_changes():
-    raise NotImplementedError("Flame use native workfile management")
+    raise NotImplementedError("Flame uses native workfile management")
 
 
 def save_file(filepath):
-    raise NotImplementedError("Flame use native workfile management")
+    raise NotImplementedError("Flame uses native workfile management")
 
 
 def open_file(filepath):
-    raise NotImplementedError("Flame use native workfile management")
+    raise NotImplementedError("Flame uses native workfile management")
 
 
 def current_file():
-    raise NotImplementedError("Flame use native workfile management")
+    raise NotImplementedError("Flame uses native workfile management")
 
 
 def work_root(session):

--- a/client/ayon_flame/plugins/create/create_batch.py
+++ b/client/ayon_flame/plugins/create/create_batch.py
@@ -1,0 +1,159 @@
+"""Creator plugin for Flame Batch.
+
+Will create a new workfile instance from current batch.
+"""
+from typing import Optional, Dict, Any, List, Tuple
+
+import json
+
+from ayon_core.pipeline import CreatedInstance
+
+import ayon_flame.api as flapi
+
+import flame
+
+
+# Name of the hidden Note node used to embed instance data inside the batch.
+_METADATA_NODE_NAME = "AYON_metadata"
+
+
+class CreateBatchWorkfile(flapi.FlameCreator):
+    """Batch workfile creator (stores instance data in a Note node).
+    """
+    settings_category = "flame"
+
+    identifier = "io.ayon.creators.flame.batch.workfile"
+    label = "Batch"
+    product_base_type = "workfile"
+    product_type = product_base_type
+    icon = "fa5.file-code"
+    default_variant = "Main"
+
+    detailed_description = """
+Publishing batch from Batch panel.
+"""
+
+    def apply_settings(self, project_settings):
+        super().apply_settings(project_settings)
+        # Only active in Batch context.
+        self.enabled = (flapi.CTX.context == "FlameMenuBatch")
+
+    @staticmethod
+    def _get_current_batch() -> flame.PyBatch:
+        """ Return the current flame.batch object or None.
+        """
+        try:
+            return flame.batch
+        except Exception as error:
+            raise RuntimeError(
+                "Cannot find current batch from context."
+            ) from error
+
+    def _get_metadata_node(
+            self,
+            create: bool = True
+        ) -> Optional[flame.PyNode]:
+        """ Find or create the AYON metadata Note node in the current batch.
+        """
+        batch = self._get_current_batch()
+        for node in batch.nodes:
+            if node.name.get_value() == _METADATA_NODE_NAME:
+                return node
+
+        if not create:
+            return None
+
+        node = batch.create_node("Note")
+        node.name.set_value(_METADATA_NODE_NAME)
+        return node
+
+    def _dump_instance_data(self, data: Dict[str, Any]):
+        """ Write instance data into the batch metadata Note node.
+        """
+        node = self._get_metadata_node()
+        node.note = json.dumps(data)
+
+    def _load_instance_data(self) -> Dict[str, Any]:
+        """ Read instance data from the batch metadata Note node.
+        """
+        node = self._get_metadata_node(create=False)
+        if not node:
+            return {}
+
+        raw = node.note.get_value()
+
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            self.log.warning("Failed to parse AYON metadata from Note node.")
+            return {}
+
+    def create(
+            self,
+            product_name: str,
+            instance_data: Dict[str, Any],
+            pre_create_data: Dict[str, Any]
+        ):
+        """Create a batch workfile instance.
+        """
+        # Set flame_context directly.
+        # Skip FlameCreator.create() which runs reel/clip
+        # logic irrelevant to the batch context.
+        instance_data["flame_context"] = flapi.CTX.context
+
+        try:
+            batch = self._get_current_batch()
+        except RuntimeError:
+            self.log.warning("No active batch group found, skipping.")
+            return
+        batch_name = batch.name.get_value()
+        self.log.info(f"Creating batch workfile instance for: {batch_name}")
+        instance_data["batch_name"] = batch_name
+
+        # TODO: check this logic with prod use-cases.
+        product_name = batch_name.replace(" ", "")
+
+        instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+        )
+        self._add_instance_to_context(instance)
+        self._dump_instance_data(instance.data_to_store())
+
+    def collect_instances(self):
+        """ Collect existing batch instance from the metadata Note node.
+        """
+        data = self._load_instance_data()
+        if not data:
+            # No data found, nothing to collect
+            return
+
+        instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=data["productName"],
+            data=data,
+            creator=self,
+        )
+        self._add_instance_to_context(instance)
+
+    def update_instances(self, update_list: List[Tuple[CreatedInstance, Any]]):
+        """ Persist updated instance data to the metadata Note node.
+        """
+        for created_inst, _ in update_list:
+            self._dump_instance_data(created_inst.data_to_store())
+
+    def remove_instances(self, instances: List[CreatedInstance]):
+        """Remove instance and delete the metadata Note node from the batch.
+        """
+        for instance in instances:
+            self._remove_instance_from_context(instance)
+
+        node = self._get_metadata_node(create=False)
+        if node:
+            node.delete()

--- a/client/ayon_flame/plugins/create/create_batch.py
+++ b/client/ayon_flame/plugins/create/create_batch.py
@@ -4,8 +4,6 @@ Will create a new workfile instance from current batch.
 """
 from typing import Optional, Dict, Any, List, Tuple
 
-import json
-
 from ayon_core.pipeline import CreatedInstance
 
 import ayon_flame.api as flapi
@@ -71,8 +69,7 @@ Publishing batch from Batch panel.
         """ Write instance data into the batch metadata Note node.
         """
         node = self._get_metadata_node()
-        node.note = json.dumps(data)
-        node.note_collapsed = True
+        flapi.write_node_metadata(node, data)
 
     def _load_instance_data(self) -> Dict[str, Any]:
         """ Read instance data from the batch metadata Note node.
@@ -81,15 +78,10 @@ Publishing batch from Batch panel.
         if not node:
             return {}
 
-        raw = node.note.get_value()
-
-        if not raw:
+        data = flapi.read_node_metadata(node)
+        if data is None:
             return {}
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            self.log.warning("Failed to parse AYON metadata from Note node.")
-            return {}
+        return data
 
     def create(
             self,

--- a/client/ayon_flame/plugins/create/create_batch.py
+++ b/client/ayon_flame/plugins/create/create_batch.py
@@ -72,6 +72,7 @@ Publishing batch from Batch panel.
         """
         node = self._get_metadata_node()
         node.note = json.dumps(data)
+        node.note_collapsed = True
 
     def _load_instance_data(self) -> Dict[str, Any]:
         """ Read instance data from the batch metadata Note node.

--- a/client/ayon_flame/plugins/create/create_batch_render.py
+++ b/client/ayon_flame/plugins/create/create_batch_render.py
@@ -1,0 +1,147 @@
+"""Creates a render product instance per selected Write File node,
+storing instance metadata directly in the node's note attribute.
+"""
+from typing import Dict, Any, List, Tuple
+
+from ayon_core.lib import BoolDef
+from ayon_core.pipeline import CreatedInstance, CreatorError
+
+import ayon_flame.api as flapi
+
+import flame
+
+
+class CreateBatchRender(flapi.FlameCreator):
+    """Create render product instances from selected Write File nodes.
+    """
+
+    settings_category = "flame"
+
+    identifier = "io.ayon.creators.flame.batch.render"
+    label = "Batch Render"
+    product_type = "render"
+    product_base_type = "render"
+    icon = "fa5.film"
+    default_variant = "Main"
+
+    detailed_description = """
+Create render product from selected Write File nodes in the
+current batch group.
+"""
+
+    def apply_settings(self, project_settings):
+        super().apply_settings(project_settings)
+        # Only active in Batch context.
+        self.enabled = (flapi.CTX.context == "FlameMenuBatch")
+
+    @staticmethod
+    def _get_write_file_nodes() -> List[flame.PyWriteFileNode]:
+        """ Return Write File nodes from the current batch selection. """
+        selected = flame.batch.selected_nodes.get_value()
+        return [
+            node for node in selected
+            if isinstance(node, flame.PyWriteFileNode)
+        ]
+
+    def get_instance_attr_defs(self) -> List[BoolDef]:
+        return [
+            BoolDef(
+                "review",
+                default=True,
+                label="Review"
+            )
+        ]
+
+    def create(
+            self,
+            product_name: str,
+            instance_data: Dict[str, Any],
+            pre_create_data: Dict[str, Any],
+    ):
+        """Create a render instance for each selected Write File node."""
+        instance_data["flame_context"] = flapi.CTX.context
+
+        nodes = self._get_write_file_nodes()
+        if not nodes:
+            raise CreatorError("No 'Write File' nodes found from selection.")
+
+        if len(nodes) > 1:
+            # TODO: How to handle multiple selected 'Write File' nodes?
+            # Currently they'd all produce the same product name.
+            raise CreatorError("Multiple selected 'Write File' nodes.")
+
+        batch_name = flame.batch.name.get_value()
+
+        for node in nodes:
+            node_name = node.name.get_value()
+
+            node_instance_data = dict(instance_data)
+            node_instance_data["batch_name"] = batch_name
+            node_instance_data["write_node_name"] = node_name
+
+            instance = CreatedInstance(
+                product_base_type=self.product_base_type,
+                product_type=self.product_type,
+                product_name=product_name,
+                data=node_instance_data,
+                creator=self,
+            )
+            self._add_instance_to_context(instance)
+            flapi.write_node_metadata(node, instance.data_to_store())
+            self.log.info(
+                f"Created render instance '{product_name}' "
+                f"from node '{node_name}'."
+            )
+
+    def collect_instances(self):
+        """ Collect existing instances from Write File node metadata. """
+        for node in list(flame.batch.nodes):
+            # Only process Write File nodes.
+            if not isinstance(node, flame.PyWriteFileNode):
+                continue
+
+            data = flapi.read_node_metadata(node)
+            # Not registered with AYON, skip.
+            if not data:
+                continue
+
+            instance = CreatedInstance(
+                product_base_type=self.product_base_type,
+                product_type=self.product_type,
+                product_name=data["productName"],
+                data=data,
+                creator=self,
+            )
+            self._add_instance_to_context(instance)
+
+    def update_instances(self, update_list: List[Tuple[CreatedInstance, Any]]):
+        """ Persist updated instance data back to the Write File node. """
+        all_nodes = {
+            node.name.get_value(): node
+            for node in list(flame.batch.nodes)
+            if isinstance(node, flame.PyWriteFileNode)
+        }
+        for created_inst, _ in update_list:
+            node_name = created_inst.data.get("write_node_name")
+            node = all_nodes.get(node_name)
+            if node:
+                flapi.write_node_metadata(node, created_inst.data_to_store())
+
+            else:
+                self.log.warning(
+                    f"Write File node '{node_name}' not found."
+                )
+
+    def remove_instances(self, instances: List[CreatedInstance]):
+        """ Clear AYON metadata from the associated Write File nodes. """
+        all_nodes = {
+            node.name.get_value(): node
+            for node in list(flame.batch.nodes)
+            if isinstance(node, flame.PyWriteFileNode)
+        }
+        for instance in instances:
+            self._remove_instance_from_context(instance)
+            node_name = instance.data.get("write_node_name")
+            node = all_nodes.get(node_name)
+            if node:
+                flapi.clear_node_metadata(node)

--- a/client/ayon_flame/plugins/create/create_batch_render.py
+++ b/client/ayon_flame/plugins/create/create_batch_render.py
@@ -12,7 +12,7 @@ import flame
 
 
 class CreateBatchRender(flapi.FlameCreator):
-    """Create render product instances from selected Write File nodes.
+    """Create render product instances from selected Write File node.
     """
 
     settings_category = "flame"
@@ -25,7 +25,7 @@ class CreateBatchRender(flapi.FlameCreator):
     default_variant = "Main"
 
     detailed_description = """
-Create render product from selected Write File nodes in the
+Create render product from selected Write File node in the
 current batch group.
 """
 
@@ -66,7 +66,7 @@ current batch group.
             raise CreatorError("No 'Write File' nodes found from selection.")
 
         if len(nodes) > 1:
-            # TODO: How to handle multiple selected 'Write File' nodes?
+            # TODO: How to handle multiple selected 'Write File' nodes ?
             # Currently they'd all produce the same product name.
             raise CreatorError("Multiple selected 'Write File' nodes.")
 

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -25,7 +25,14 @@ class LoadBatchgroup(LoaderPlugin):
         """Load new batch from consolidated json file.
         """
         path = self.filepath_from_context(context)
-        _ = batch_utils.load_batch_from_consolidated_json(path)
+        version_data = context.get("version", {}).get("data", {})
+        batch_name = version_data.get("batch_name")
+
+        batch = batch_utils.load_batch_from_consolidated_json(
+            path,
+            name=batch_name
+        )
+        self.log.info(f"Loaded batch: {batch}")
         #TODO: match with batchgroup iteration
 
     def update(self, container, context):

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -124,6 +124,7 @@ class LoadBatchgroup(LoaderPlugin):
             f"Loaded batch group with {iterations} versions as iterations."
         )
 
+        # Set requested version as current iteration.
         if current_iteration:
             flame.batch.replace_setup(current_iteration)
             self.log.debug(

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -72,8 +72,8 @@ class LoadBatchgroup(LoaderPlugin):
                 "warning",
                 ["OK"],
             )
-            batch_name = unique_batch_name
-            flame.batch.create_batch_group(batch_name)
+        batch_name = unique_batch_name
+        flame.batch.create_batch_group(batch_name)
 
         # Collect all versions sorted oldest → newest.
         all_versions = sorted(

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -1,4 +1,7 @@
+from copy import deepcopy
 from typing import Optional, Dict
+
+import ayon_api
 
 from ayon_core.pipeline import LoaderPlugin
 
@@ -22,18 +25,77 @@ class LoadBatchgroup(LoaderPlugin):
             namespace: Optional[str] = None,
             options: Optional[Dict] = None,
     ):
-        """Load new batch from consolidated json file.
-        """
-        path = self.filepath_from_context(context)
-        version_data = context.get("version", {}).get("data", {})
-        batch_name = version_data.get("batch_name")
+        """Load all published versions as native Flame batch iterations.
 
-        batch = batch_utils.load_batch_from_consolidated_json(
-            path,
-            name=batch_name
+        Each AYON version is loaded as a named iteration (v001, v002, …)
+        inside a single batch group. Switch between versions via the Flame UI
+        (right-click batch → Iterations). Programmatic iteration switching is
+        not supported by the Flame Python API.
+        """
+        import flame
+
+        project_name = context["project"]["name"]
+        product_id = context["version"]["productId"]
+        requested_version_entity = context["version"]
+        batch_name = (
+            requested_version_entity.get("data", {}).get("batch_name")
+            or context["representation"]["context"].get("asset")
         )
-        self.log.info(f"Loaded batch: {batch}")
-        #TODO: match with batchgroup iteration
+
+        # Collect all versions sorted oldest → newest.
+        all_versions = sorted(
+            ayon_api.get_versions(project_name, product_ids=[product_id]),
+            key=lambda v: v["version"],
+        )
+
+        # Collect matching representations per version.
+        repres_by_version_id = {
+            r["versionId"]: r
+            for r in ayon_api.get_representations(
+                project_name,
+                representation_names={context["representation"]["name"]},
+                version_ids=[v["id"] for v in all_versions],
+            )
+        }
+
+        if not repres_by_version_id:
+            raise RuntimeError(
+                f"No representations found for product '{product_id}' "
+                f"in project '{project_name}'."
+            )
+
+        current_iteration = None
+        iterations = 0
+        for version in all_versions:
+            repre = repres_by_version_id.get(version["id"])
+            if not repre:
+                continue
+
+            iterations += 1
+            version_context = deepcopy(context)
+            version_context["version"] = version
+            version_context["representation"] = repre
+
+            filepath = self.filepath_from_context(version_context)
+            batch_utils.load_batch_from_consolidated_json(
+                filepath,
+                name=batch_name,
+            )
+            flame.batch.iterate()
+
+            if requested_version_entity["id"] == version["id"]:
+                current_iteration = flame.batch.batch_iterations[-1]
+
+        self.log.debug(
+            f"Loaded batch group with {iterations} versions as iterations."
+        )
+
+        if current_iteration:
+            flame.batch.replace_setup(current_iteration)
+            self.log.debug(
+                f'Set {requested_version_entity["version"]} '
+                f"as current batch iteration."
+            )
 
     def update(self, container, context):
         raise NotImplementedError(

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -8,6 +8,24 @@ from ayon_core.pipeline import LoaderPlugin
 from ayon_flame.api import batch_utils
 
 
+def _unique_batch_name(name: str) -> str:
+    """Return a unique batch group name, appending (2), (3)… if needed."""
+    import flame
+
+    existing = {
+        bg.name.get_value()
+        for bg in flame.project.current_project.current_workspace
+            .desktop.batch_groups
+    }
+    if name not in existing:
+        return name
+
+    counter = 2
+    while f"{name} ({counter})" in existing:
+        counter += 1
+    return f"{name} ({counter})"
+
+
 class LoadBatchgroup(LoaderPlugin):
     product_types = {"workfile"}
     representations = {"*"}
@@ -27,10 +45,10 @@ class LoadBatchgroup(LoaderPlugin):
     ):
         """Load all published versions as native Flame batch iterations.
 
-        Each AYON version is loaded as a named iteration (v001, v002, …)
-        inside a single batch group. Switch between versions via the Flame UI
-        (right-click batch → Iterations). Programmatic iteration switching is
-        not supported by the Flame Python API.
+        Each AYON version is loaded as an iteration inside a single batch
+        group.
+        If a batch group with the same name already exists in the workspace,
+        a unique name is generated automatically (e.g. "MyBatch (2)").
         """
         import flame
 
@@ -41,6 +59,21 @@ class LoadBatchgroup(LoaderPlugin):
             requested_version_entity.get("data", {}).get("batch_name")
             or context["representation"]["context"].get("asset")
         )
+        unique_batch_name = _unique_batch_name(batch_name)
+        if unique_batch_name != batch_name:
+            self.log.warning(
+                f"Batch group '{batch_name}' already exists. "
+                f"Loading as '{unique_batch_name}'."
+            )
+            flame.messages.show_in_dialog(
+                "Existing Batch Group",
+                f"A batch group with the name '{batch_name}' already exists. "
+                f"Loading as '{unique_batch_name}'.",
+                "warning",
+                ["OK"],
+            )
+            batch_name = unique_batch_name
+            flame.batch.create_batch_group(batch_name)
 
         # Collect all versions sorted oldest → newest.
         all_versions = sorted(
@@ -66,6 +99,7 @@ class LoadBatchgroup(LoaderPlugin):
 
         current_iteration = None
         iterations = 0
+
         for version in all_versions:
             repre = repres_by_version_id.get(version["id"])
             if not repre:

--- a/client/ayon_flame/plugins/load/load_batch.py
+++ b/client/ayon_flame/plugins/load/load_batch.py
@@ -1,0 +1,41 @@
+from typing import Optional, Dict
+
+from ayon_core.pipeline import LoaderPlugin
+
+from ayon_flame.api import batch_utils
+
+
+class LoadBatchgroup(LoaderPlugin):
+    product_types = {"workfile"}
+    representations = {"*"}
+    extensions = ("json",)
+
+    label = "Load batch"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    def load(
+            self,
+            context: Dict,
+            name: Optional[str] = None,
+            namespace: Optional[str] = None,
+            options: Optional[Dict] = None,
+    ):
+        """Load new batch from consolidated json file.
+        """
+        path = self.filepath_from_context(context)
+        _ = batch_utils.load_batch_from_consolidated_json(path)
+        #TODO: match with batchgroup iteration
+
+    def update(self, container, context):
+        raise NotImplementedError(
+            "Version management rely on Flame "
+            "native batch iteration implementation."
+        )
+
+    def remove(self, container):
+        raise NotImplementedError(
+            "Version management rely on Flame "
+            "native batch iteration implementation."
+        )

--- a/client/ayon_flame/plugins/load/load_clip.py
+++ b/client/ayon_flame/plugins/load/load_clip.py
@@ -1,26 +1,11 @@
 import flame
+
 import ayon_flame.api as ayfapi
-from ayon_core.lib.transcoding import (
-    VIDEO_EXTENSIONS,
-    IMAGE_EXTENSIONS
-)
 
 
 class LoadClip(ayfapi.ClipLoader):
-    """Load a product to timeline as clip
-
-    Place clip to timeline on its asset origin timings collected
-    during conforming to project
+    """Load a media product to as clip in the media panel.
     """
-
-    product_base_types = {
-        "render2d", "source", "plate", "render", "review"
-    }
-    representations = {"*"}
-    extensions = set(
-        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
-    )
-
     label = "Load as clip"
     order = -10
     icon = "code-fork"
@@ -31,11 +16,6 @@ class LoadClip(ayfapi.ClipLoader):
     reel_name = "Loaded"
     clip_name_template = "{folder[name]}_{product[name]}<_{output}>"
 
-    """ Anatomy keys from version context data and dynamically added:
-        - {layerName} - original layer name token
-        - {layerUID} - original layer UID token
-        - {originalBasename} - original clip name taken from file
-    """
     layer_rename_template = "{folder[name]}_{product[name]}<_{output}>"
     layer_rename_patterns = []
 
@@ -44,21 +24,21 @@ class LoadClip(ayfapi.ClipLoader):
         return self.product_base_types
 
     def _get_reel(self):
+        """ Retrieve or create a reel_group/reel for loaded clips.
+        """
+        for reel_group in self.fpd.reel_groups:
+            # Expected reel group from settings exists, retrieve.
+            if reel_group.name.get_value() == self.reel_group_name:
+                break
 
-        matching_rgroup = [
-            rg for rg in self.fpd.reel_groups
-            if rg.name.get_value() == self.reel_group_name
-        ]
-
-        if not matching_rgroup:
-            reel_group = self.fpd.create_reel_group(str(self.reel_group_name))
-            for _r in reel_group.reels:
-                if "reel" not in _r.name.get_value().lower():
-                    continue
-                self.log.debug("Removing: {}".format(_r.name))
-                flame.delete(_r)
+        # Create new empty reel group.
         else:
-            reel_group = matching_rgroup.pop()
+            reel_group = self.fpd.create_reel_group(str(self.reel_group_name))
+            for reel in reel_group.reels:
+                if "reel" not in reel.name.get_value().lower():
+                    continue
+                self.log.debug(f"Removing useless reel: {reel.name}")
+                flame.delete(reel)
 
         matching_reel = [
             re for re in reel_group.reels
@@ -66,8 +46,6 @@ class LoadClip(ayfapi.ClipLoader):
         ]
 
         if not matching_reel:
-            reel_group = reel_group.create_reel(str(self.reel_name))
-        else:
-            reel_group = matching_reel.pop()
+            return reel_group.create_reel(str(self.reel_name))
 
-        return reel_group
+        return matching_reel.pop()

--- a/client/ayon_flame/plugins/load/load_clip.py
+++ b/client/ayon_flame/plugins/load/load_clip.py
@@ -37,7 +37,9 @@ class LoadClip(ayfapi.ClipLoader):
             for reel in reel_group.reels:
                 if "reel" not in reel.name.get_value().lower():
                     continue
-                self.log.debug(f"Removing useless reel: {reel.name}")
+                self.log.debug(
+                    f"Removing useless reel: {reel.name.get_value()}"
+                )
                 flame.delete(reel)
 
         matching_reel = [

--- a/client/ayon_flame/plugins/load/load_clip.py
+++ b/client/ayon_flame/plugins/load/load_clip.py
@@ -4,7 +4,7 @@ import ayon_flame.api as ayfapi
 
 
 class LoadClip(ayfapi.ClipLoader):
-    """Load a media product to as clip in the media panel.
+    """ Load a media product as a clip in the media panel.
     """
     label = "Load as clip"
     order = -10

--- a/client/ayon_flame/plugins/load/load_clip_batch.py
+++ b/client/ayon_flame/plugins/load/load_clip_batch.py
@@ -1,25 +1,13 @@
+from __future__ import annotations
+
 import flame
+
 import ayon_flame.api as ayfapi
-from ayon_core.lib.transcoding import (
-    VIDEO_EXTENSIONS,
-    IMAGE_EXTENSIONS
-)
+
 
 class LoadClipBatch(ayfapi.ClipLoader):
-    """Load a product to timeline as clip
-
-    Place clip to timeline on its asset origin timings collected
-    during conforming to project
+    """Load a media product as clip into a batch reel.
     """
-
-    product_base_types = {
-        "render2d", "source", "plate", "render", "review"
-    }
-    representations = {"*"}
-    extensions = set(
-        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
-    )
-
     label = "Load as clip to current batch"
     order = -10
     icon = "code-fork"
@@ -29,11 +17,6 @@ class LoadClipBatch(ayfapi.ClipLoader):
     reel_name = "AYON_LoadedReel"
     clip_name_template = "{batch}_{folder[name]}_{product[name]}<_{output}>"
 
-    """ Anatomy keys from version context data and dynamically added:
-        - {layerName} - original layer name token
-        - {layerUID} - original layer UID token
-        - {originalBasename} - original clip name taken from file
-    """
     layer_rename_template = "{folder[name]}_{product[name]}<_{output}>"
     layer_rename_patterns = []
 
@@ -41,35 +24,22 @@ class LoadClipBatch(ayfapi.ClipLoader):
     def product_types(self):
         return self.product_base_types
 
-    def _get_formatting_data(self, context, options):
-        formatting_data = super()._get_formatting_data(context, options)
+    def load(self, context, name, namespace, options):
         self.batch = options.get("batch") or flame.batch
-        folder_entity = context["folder"]
-        product_entity = context["product"]
+        return super().load(context, name, namespace, options)
+
+    def _get_clip_name_format_data(self, context, options) -> dict[str, str]:
+        """ Get formatting data for the clip name template.
+        """
+        formatting_data = super()._get_clip_name_format_data(context, options)
         formatting_data["batch"] = self.batch.name.get_value()
-        formatting_data.update({
-            "asset": folder_entity["name"],
-            "folder": {
-                "name": folder_entity["name"],
-            },
-            "subset": product_entity["name"],
-            "family": product_entity["productType"],
-            "product": {
-                "name": product_entity["name"],
-                "type": product_entity["productType"],
-                "basetype": product_entity["productBaseType"],
-            }
-        })
         return formatting_data
 
     def _get_reel(self):
-        matching_reel = [
-            rg for rg in self.batch.reels
-            if rg.name.get_value() == self.reel_name
-        ]
+        """ Retrieve/Create expected reel from current batch.
+        """
+        for reel in self.batch.reels:
+            if reel.name.get_value() == self.reel_name:
+                return reel
 
-        return (
-            matching_reel.pop()
-            if matching_reel
-            else self.batch.create_reel(str(self.reel_name))
-        )
+        return self.batch.create_reel(str(self.reel_name))

--- a/client/ayon_flame/plugins/load/load_clip_batch.py
+++ b/client/ayon_flame/plugins/load/load_clip_batch.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import flame
 
@@ -28,7 +29,7 @@ class LoadClipBatch(ayfapi.ClipLoader):
         self.batch = options.get("batch") or flame.batch
         return super().load(context, name, namespace, options)
 
-    def _get_clip_name_format_data(self, context, options) -> dict[str, str]:
+    def _get_clip_name_format_data(self, context, options) -> dict[str, Any]:
         """ Get formatting data for the clip name template.
         """
         formatting_data = super()._get_clip_name_format_data(context, options)

--- a/client/ayon_flame/plugins/publish/collect_render_from_batch.py
+++ b/client/ayon_flame/plugins/publish/collect_render_from_batch.py
@@ -1,0 +1,31 @@
+"""Collect render instances from batch Write File nodes."""
+import pyblish.api
+
+
+class CollectRenderFromBatch(pyblish.api.InstancePlugin):
+    """Collect batch render instances and handle the review attribute."""
+
+    order = pyblish.api.CollectorOrder + 0.49
+    label = "Collect Render from Batch"
+    hosts = ["flame"]
+    families = ["render"]
+
+    def process(self, instance):
+        if (
+            instance.data.get("flame_context") != "FlameMenuBatch"
+            or not instance.data.get("write_node_name")
+        ):
+            self.log.debug("No valid batch render instance, skipping.")
+            return
+
+        if instance.data.get("creator_attributes", {}).get("review"):
+            instance.data["families"].append("review")
+            self.log.debug(
+                f"Review enabled for render instance '{instance.name}'."
+            )
+
+        self.log.debug(
+            f"Collected render instance '{instance.name}' "
+            f"from Write File node '{instance.data.get('write_node_name')}'. "
+            f"Families: {instance.data['families']}"
+        )

--- a/client/ayon_flame/plugins/publish/extract_batch_render.py
+++ b/client/ayon_flame/plugins/publish/extract_batch_render.py
@@ -55,14 +55,18 @@ class ExtractBatchRender(publish.Extractor):
             )
 
         # Render once per publish context across all render instances.
-        if not instance.context.data.get(self._RENDER_DONE_KEY):
+        render_context = instance.context.data.setdefault(
+            self._RENDER_DONE_KEY, {}
+        )
+        if not render_context.get(batch_name):
             self.log.info(f"Rendering batch '{batch_name}'.")
             success = batch.render()  # render_option='Foreground' (blocking)
             if not success:
-                raise RuntimeError(
+                raise PublishError(
                     f"Flame batch render failed for '{batch_name}'."
                 )
-            instance.context.data[self._RENDER_DONE_KEY] = True
+
+            render_context[batch_name] = True
             self.log.info(f"Batch '{batch_name}' rendered successfully.")
 
         else:
@@ -84,7 +88,7 @@ class ExtractBatchRender(publish.Extractor):
         if not is_sequence:
             single_file = Path(output_dir) / resolved_name
             if not single_file.exists():
-                raise RuntimeError(
+                raise PublishError(
                     f"Output file not found after render: {single_file}"
                 )
             written_files = [resolved_name]
@@ -92,7 +96,7 @@ class ExtractBatchRender(publish.Extractor):
         else:
             output_path = Path(output_dir)
             if not output_path.exists():
-                raise RuntimeError(
+                raise PublishError(
                     f"Output directory not found after render: {output_dir}"
                 )
 
@@ -110,7 +114,8 @@ class ExtractBatchRender(publish.Extractor):
             )
         if not written_files:
             raise ValueError(
-                f"Expected {resolved_path} files found in output directory."
+                f"Expected {resolved_path} files is not found "
+                "in output directory."
             )
 
         if "representations" not in instance.data:

--- a/client/ayon_flame/plugins/publish/extract_batch_render.py
+++ b/client/ayon_flame/plugins/publish/extract_batch_render.py
@@ -1,0 +1,133 @@
+""" Extract render output from Flame batch Write File nodes. """
+import os
+
+from pathlib import Path
+
+import pyblish.api
+
+from ayon_core.pipeline import publish, PublishError
+
+import ayon_flame.api as flapi
+
+
+class ExtractBatchRender(publish.Extractor):
+    """Render the batch then collect Write File outputs as representations.
+    """
+
+    label = "Extract Batch Render"
+    order = pyblish.api.ExtractorOrder
+    families = ["render"]
+    hosts = ["flame"]
+
+    # Context key used to ensure render is triggered only once per publish.
+    # Could be multiple batch renders per publish context.
+    _RENDER_DONE_KEY = "_batch_render_done"
+
+    def process(self, instance):
+        import flame
+
+        write_node_name = instance.data.get("write_node_name")
+        if not write_node_name:
+            self.log.warning("No write_node_name in instance data, skipping.")
+            return
+
+        # Find the batch group by name.
+        batch_name = instance.data.get("batch_name")
+        batch = flapi.get_batch_from_workspace(batch_name)
+        if not batch:
+            raise PublishError(
+                f"Batch group not found in workspace: '{batch_name}'."
+            )
+
+        # Find the Write File node by name.
+        write_node = next(
+            (
+                n for n in batch.nodes
+                if isinstance(n, flame.PyWriteFileNode)
+                and n.name.get_value() == write_node_name
+            ),
+            None,
+        )
+        if write_node is None:
+            raise PublishError(
+                f"Write File node '{write_node_name}' not found "
+                f"in batch '{batch_name}'."
+            )
+
+        # Render once per publish context across all render instances.
+        if not instance.context.data.get(self._RENDER_DONE_KEY):
+            self.log.info(f"Rendering batch '{batch_name}'.")
+            success = batch.render()  # render_option='Foreground' (blocking)
+            if not success:
+                raise RuntimeError(
+                    f"Flame batch render failed for '{batch_name}'."
+                )
+            instance.context.data[self._RENDER_DONE_KEY] = True
+            self.log.info(f"Batch '{batch_name}' rendered successfully.")
+
+        else:
+            self.log.debug("Batch already rendered, no need to re-render.")
+
+        # get_resolved_media_path() returns either:
+        # - a sequence pattern: /path/file.[0001001-0001050].exr
+        # - a single file:      /path/output.mov
+        resolved_path = write_node.get_resolved_media_path()
+        output_dir = os.path.dirname(resolved_path)
+        resolved_name = os.path.basename(resolved_path)
+
+        bracket_pos = resolved_name.find("[")
+        is_sequence = bracket_pos != -1
+        _, ext = os.path.splitext(resolved_name)
+        ext = ext.lstrip(".")
+
+        # Single file output, check the exact file exists.
+        if not is_sequence:
+            single_file = Path(output_dir) / resolved_name
+            if not single_file.exists():
+                raise RuntimeError(
+                    f"Output file not found after render: {single_file}"
+                )
+            written_files = [resolved_name]
+
+        else:
+            output_path = Path(output_dir)
+            if not output_path.exists():
+                raise RuntimeError(
+                    f"Output directory not found after render: {output_dir}"
+                )
+
+            name_prefix = resolved_name[:bracket_pos]
+
+            # Scan output directory for written files.
+            # NOTE: Pre-existing files matching the extension will be included.
+            # If the Write File node is configured to overwrite the same output
+            # path across multiple publishes, older files are picked up too.
+            written_files = sorted(
+                f.name for f in output_path.iterdir()
+                if f.is_file()
+                and f.suffix.lstrip(".").lower() == ext.lower()
+                and f.name.startswith(name_prefix)
+            )
+        if not written_files:
+            raise ValueError(
+                f"Expected {resolved_path} files found in output directory."
+            )
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        representation = {
+            "name": ext,
+            "ext": ext,
+            "outputName": ext,
+            "files": (
+                written_files if len(written_files) > 1 else written_files[0]
+            ),
+            "stagingDir": output_dir,
+            "tags": [],
+        }
+        instance.data["representations"].append(representation)
+        self.log.info(
+            f"Collected render representation from '{write_node_name}': "
+            f"{output_dir} ({len(written_files)} file(s))."
+        )

--- a/client/ayon_flame/plugins/publish/extract_batch_workfile.py
+++ b/client/ayon_flame/plugins/publish/extract_batch_workfile.py
@@ -1,0 +1,44 @@
+"""Extract batch group as a consolidated JSON workfile."""
+import os
+import pyblish.api
+
+from ayon_core.pipeline import publish
+import ayon_flame.api as flapi
+
+
+class ExtractBatchWorkfile(publish.Extractor):
+    """Export the current batch group as a consolidated JSON workfile."""
+
+    label = "Extract Batch Workfile"
+    order = pyblish.api.ExtractorOrder - 0.45
+    families = ["workfile"]
+    hosts = ["flame"]
+
+    def process(self, instance):
+        if instance.data.get("batch_name") is None:
+            self.log.warning("No batch_name found in instance data, skipping.")
+            return
+
+        if "representations" not in instance.data:
+            instance.data["representations"] = []
+
+        batch_name = instance.data.get("batch_name")
+        batch = flapi.get_batch_from_workspace(batch_name)
+        if not batch:
+            raise ValueError(f"Batch group not found: {batch_name}")
+
+        staging_dir = self.staging_dir(instance)
+        filename = f"{batch_name}.json"
+        filepath = os.path.join(staging_dir, filename)
+        flapi.save_batch_as_consolidated_json(batch, filepath)
+
+        representation = {
+            "name": "batch",
+            "ext": "json",
+            "files": filename,
+            "stagingDir": staging_dir,
+        }
+        instance.data["representations"].append(representation)
+        self.log.info(
+            f"Extracted batch workfile representation: {representation}"
+        )

--- a/client/ayon_flame/plugins/publish/extract_batch_workfile.py
+++ b/client/ayon_flame/plugins/publish/extract_batch_workfile.py
@@ -39,6 +39,11 @@ class ExtractBatchWorkfile(publish.Extractor):
             "stagingDir": staging_dir,
         }
         instance.data["representations"].append(representation)
+
+        # Preserve batch name in version data for reference and loading.
+        version_data = instance.data.setdefault("versionData", {})
+        version_data["batch_name"] = batch_name
+
         self.log.info(
             f"Extracted batch workfile representation: {representation}"
         )

--- a/client/ayon_flame/plugins/publish/integrate_batch_group.py
+++ b/client/ayon_flame/plugins/publish/integrate_batch_group.py
@@ -3,9 +3,11 @@ import copy
 from collections import OrderedDict
 from pprint import pformat
 import pyblish
-import ayon_flame.api as ayfapi
+
 import ayon_core.pipeline as op_pipeline
 from ayon_core.pipeline.workfile import get_workdir
+
+import ayon_flame.api as ayfapi
 
 
 class IntegrateBatchGroup(pyblish.api.InstancePlugin):
@@ -81,8 +83,11 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
         ]
 
         # add nodes into batch group
-        return ayfapi.create_batch_group_conent(
-            batch_nodes, batch_links, batch_group)
+        return ayfapi.edit_batch_group_content(
+            batch_group,
+            batch_nodes,
+            batch_links
+        )
 
     def _load_clip_to_context(self, instance, bgroup):
         # get all loaders for host
@@ -175,43 +180,33 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
         task_name = task_data["name"]
         batchgroup_name = "{}_{}".format(folder_path, task_name)
 
-        batch_data = {
-            "shematic_reels": [
-                "AYON_LoadedReel"
-            ],
-            "handleStart": handle_start,
-            "handleEnd": handle_end
-        }
-        self.log.debug(
-            "__ batch_data: {}".format(pformat(batch_data)))
-
-        # check if the batch group already exists
-        bgroup = ayfapi.get_batch_group_from_desktop(batchgroup_name)
-
-        if not bgroup:
-            self.log.info(
-                "Creating new batch group: {}".format(batchgroup_name))
-            # create batch with utils
-            bgroup = ayfapi.create_batch_group(
-                batchgroup_name,
-                frame_start,
-                frame_duration,
-                **batch_data
+        # check if parent batch group exists
+        bgroup = ayfapi.get_batch_from_workspace(batchgroup_name)
+        if bgroup:
+            self.log.info("Updating batch group: {batchgroup_name}")
+            batch = ayfapi.update_batch(
+                bgroup,
+                frame_start=frame_start,
+                frame_duration=frame_duration,
+                handle_start=handle_start,
+                handle_end=handle_end,
             )
 
         else:
-            self.log.info(
-                "Updating batch group: {}".format(batchgroup_name))
-            # update already created batch group
-            bgroup = ayfapi.create_batch_group(
+            self.log.info(f"Creating new batch group: {batchgroup_name}")
+            batch = ayfapi.create_batch(
                 batchgroup_name,
-                frame_start,
-                frame_duration,
-                update_batch_group=bgroup,
-                **batch_data
+                frame_start=frame_start,
+                frame_duration=frame_duration,
+                handle_start=handle_start,
+                handle_end=handle_end,
             )
 
-        return bgroup
+        ayfapi.add_reels_to_batch(
+            batch,
+            reels=["AYON_LoadedReel"],
+        )
+        return batch
 
     def _get_anamoty_data_with_current_task(self, instance, task_data):
         anatomy_data = copy.deepcopy(instance.data["anatomyData"])

--- a/client/ayon_flame/plugins/publish/integrate_batch_group.py
+++ b/client/ayon_flame/plugins/publish/integrate_batch_group.py
@@ -183,7 +183,7 @@ class IntegrateBatchGroup(pyblish.api.InstancePlugin):
         # check if parent batch group exists
         bgroup = ayfapi.get_batch_from_workspace(batchgroup_name)
         if bgroup:
-            self.log.info("Updating batch group: {batchgroup_name}")
+            self.log.info(f"Updating batch group: {batchgroup_name}")
             batch = ayfapi.update_batch(
                 bgroup,
                 frame_start=frame_start,

--- a/client/ayon_flame/plugins/publish/integrate_batch_iteration.py
+++ b/client/ayon_flame/plugins/publish/integrate_batch_iteration.py
@@ -1,0 +1,42 @@
+""" Offer to iterate after a successful batch publish."""
+import pyblish.api
+
+from ayon_core.pipeline.publish import OptionalPyblishPluginMixin
+
+import ayon_flame.api as flapi
+
+
+class IntegrateBatchIteration(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin,
+):
+    """Offer to save batch as new iteration after publishing is done.
+    """
+
+    label = "Iterate Batch After Publish"
+    order = pyblish.api.IntegratorOrder + 0.5
+    families = ["workfile"]
+    hosts = ["flame"]
+    optional = True
+    active = True
+
+    def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
+        if instance.data.get("batch_name") is None:
+            self.log.info(
+                "Instance is not a batch workfile, skipping."
+            )
+            return
+
+        batch_name = instance.data.get("batch_name")
+        batch = flapi.get_batch_from_workspace(batch_name)
+        if not batch:
+            raise ValueError(f"Batch group not found: {batch_name}")
+
+        batch.iterate()
+        self.log.info(
+            f"Created new batch iteration after publish "
+            f"(total: {len(batch.batch_iterations)})."
+        )

--- a/client/ayon_flame/startup/AYON_in_flame.py
+++ b/client/ayon_flame/startup/AYON_in_flame.py
@@ -85,6 +85,8 @@ def load_apps():
     flame_api.CTX.flame_apps.append(
         flame_api.FlameMenuTimeline(flame_api.CTX.app_framework))
     flame_api.CTX.flame_apps.append(
+        flame_api.FlameMenuBatch(flame_api.CTX.app_framework))
+    flame_api.CTX.flame_apps.append(
         flame_api.FlameMenuUniversal(flame_api.CTX.app_framework))
     flame_api.CTX.app_framework.log.info("Apps are loaded")
 
@@ -218,7 +220,7 @@ def get_batch_custom_ui_actions():
     # install AYON and the host
     ayon_flame_install()
 
-    return _build_app_menu("FlameMenuUniversal")
+    return _build_app_menu("FlameMenuBatch")
 
 
 def get_media_panel_custom_ui_actions():


### PR DESCRIPTION
## Changelog Description

fixes: https://github.com/ynput/ayon-flame/issues/114 and https://github.com/ynput/ayon-flame/issues/113

Consolidate `LoadClip` and `LoadClipBatch`:
* [x] `AttributeError` formatting data bug with batch group
* [x] handle incompatible Flame media input (e.g. `sxr`) 
* [x] handle version with missing representation `NoneType`
* [x] Fix video based clip import 
* [x] ensure all version for a product are sourced regardless of their optional task
* [x] factorize loader code
* [x] fix clip rename logic 

## Additional review information
Tested on Flame 2026.2 / macOs

## Testing notes:
1. Ensure LoadClip and LoadClipBatch create the relevant source clips in Flame
2. Ensure all available versions are sourced and clips are created following settings name and current version
