### PR TITLE
Fix pre-opentimelineio_install pre-hook.

### DIFF
--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -1,4 +1,6 @@
+import os
 import subprocess
+import appdirs
 
 from ayon_applications import (
     PreLaunchHook, LaunchTypes, ApplicationLaunchFailed)
@@ -42,7 +44,23 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
             self.log.info("OpenTimelineIO is installed within Flame env.")
             return
 
-        # Install it otherwise.
+        # secondly if OpenTimelineIO is installed in our custom site-packages
+        custom_site_path = self.get_custom_site_path()
+
+        # make sure the custom site-packages exists
+        os.makedirs(custom_site_path, exist_ok=True)
+
+        # add custom site-packages to PYTHONPATH
+        env["PYTHONPATH"] += f"{os.pathsep}{custom_site_path}"
+        result = subprocess.run(
+            [flame_py_exe, "-c", "import opentimelineio"], env=env
+        )
+        if result.returncode == 0:
+            self.log.info(
+                "OpenTimelineIO is installed within AYON Flame env.")
+            return
+
+        # lastly install OpenTimelineIO into our custom site-packages
         result = subprocess.run(
             [
                 flame_py_exe,
@@ -50,6 +68,8 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
                 "pip",
                 "install",
                 "opentimelineio",
+                "-t",
+                custom_site_path,
             ]
         )
         if result.returncode == 0:
@@ -60,3 +80,6 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
             return
 
         raise ApplicationLaunchFailed("Failed to install OpenTimelineIO")
+
+    def get_custom_site_path(self):
+        return appdirs.user_data_dir("ayon_flame", "Ynput")

--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 import subprocess
 
 from ayon_applications import (
@@ -46,7 +47,7 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
             return
 
         # secondly if OpenTimelineIO is installed in our custom site-packages
-        custom_site_path = self.get_custom_site_path()
+        custom_site_path = self.get_custom_site_path(flame_py_exe)
 
         # make sure the custom site-packages exists
         os.makedirs(custom_site_path, exist_ok=True)
@@ -82,8 +83,10 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
 
         raise ApplicationLaunchFailed("Failed to install OpenTimelineIO")
 
-    def get_custom_site_path(self) -> str:
+    def get_custom_site_path(self, flame_py_exe: str) -> str:
+        path_hash = hashlib.sha256(flame_py_exe.encode()).hexdigest()
         return lib.get_addons_resources_dir(
             "ayon_flame",
-            "otio_prehook"
+            "otio_prehook",
+            path_hash[:16],
         )

--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -1,6 +1,4 @@
-import os
 import subprocess
-import appdirs
 
 from ayon_applications import (
     PreLaunchHook, LaunchTypes, ApplicationLaunchFailed)
@@ -44,23 +42,7 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
             self.log.info("OpenTimelineIO is installed within Flame env.")
             return
 
-        # secondly if OpenTimelineIO is installed in our custom site-packages
-        custom_site_path = self.get_custom_site_path()
-
-        # make sure the custom site-packages exists
-        os.makedirs(custom_site_path, exist_ok=True)
-
-        # add custom site-packages to PYTHONPATH
-        env["PYTHONPATH"] += f"{os.pathsep}{custom_site_path}"
-        result = subprocess.run(
-            [flame_py_exe, "-c", "import opentimelineio"], env=env
-        )
-        if result.returncode == 0:
-            self.log.info(
-                "OpenTimelineIO is installed within AYON Flame env.")
-            return
-
-        # lastly install OpenTimelineIO into our custom site-packages
+        # Install it otherwise.
         result = subprocess.run(
             [
                 flame_py_exe,
@@ -68,8 +50,6 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
                 "pip",
                 "install",
                 "opentimelineio",
-                "-t",
-                custom_site_path,
             ]
         )
         if result.returncode == 0:
@@ -80,6 +60,3 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
             return
 
         raise ApplicationLaunchFailed("Failed to install OpenTimelineIO")
-
-    def get_custom_site_path(self):
-        return appdirs.user_data_dir("ayon_flame", "Ynput")

--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import appdirs
+import platformdirs
 
 from ayon_applications import (
     PreLaunchHook, LaunchTypes, ApplicationLaunchFailed)
@@ -82,4 +82,4 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
         raise ApplicationLaunchFailed("Failed to install OpenTimelineIO")
 
     def get_custom_site_path(self):
-        return appdirs.user_data_dir("ayon_flame", "Ynput")
+        return platformdirs.user_data_dir("ayon_flame", "Ynput")

--- a/client/ayon_flame/hooks/pre_opentimelineio_install.py
+++ b/client/ayon_flame/hooks/pre_opentimelineio_install.py
@@ -1,9 +1,10 @@
 import os
 import subprocess
-import platformdirs
 
 from ayon_applications import (
     PreLaunchHook, LaunchTypes, ApplicationLaunchFailed)
+
+from ayon_core import lib
 
 
 class InstallOpenTimelineIOToFlame(PreLaunchHook):
@@ -81,5 +82,8 @@ class InstallOpenTimelineIOToFlame(PreLaunchHook):
 
         raise ApplicationLaunchFailed("Failed to install OpenTimelineIO")
 
-    def get_custom_site_path(self):
-        return platformdirs.user_data_dir("ayon_flame", "Ynput")
+    def get_custom_site_path(self) -> str:
+        return lib.get_addons_resources_dir(
+            "ayon_flame",
+            "otio_prehook"
+        )

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.poetry.dependencies]
-platformdirs = "^4.2"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.poetry.dependencies]
-appdirs = "^1.4"
+platformdirs = "^4.2"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry.dependencies]
+appdirs = "^1.4"


### PR DESCRIPTION
## Changelog Description

Realize `pre-opentimelineio_install ` was broken on recent Flame install.
This seems to come from implicit `appdirs` requirement not present in environment.
```python
WARNING:ayon_core.lib.python_module_tools:Failed to load path: "/Users/robindelillo/Desktop/dev/ayon-flame/client/ayon_flame/hooks/pre_opentimelineio_install.py"
Traceback (most recent call last):
  File "/Users/robindelillo/Library/Application Support/AYON/addons/core_1.9.0/ayon_core/lib/python_module_tools.py", line 93, in modules_from_path
    module = import_filepath(full_path, mod_name)
  File "/Users/robindelillo/Library/Application Support/AYON/addons/core_1.9.0/ayon_core/lib/python_module_tools.py", line 45, in import_filepath
    module_loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/robindelillo/Desktop/dev/ayon-flame/client/ayon_flame/hooks/pre_opentimelineio_install.py", line 3, in <module>
    import appdirs
ModuleNotFoundError: No module named 'appdirs'
```

## Testing notes:
1. Install Flame without `opentimelineio` (uninstall it if needed)
2. Package the addon, re-build the dependency package for the test bundle
3. Re-open Flame and ensure `opentimelineio` is installed from custom app directory
