### PR TITLE
Replace qargparse with attribute definitions

### DIFF
--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -569,7 +569,7 @@ class ClipLoader(LoaderPlugin):
             "handles",
             label="Set handles",
             default=False,
-            help="Also set handles to clip as In/Out marks"
+            tooltip="Also set handles to clip as In/Out marks"
         )
     ]
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -8,13 +8,11 @@ from typing import Any, Optional
 from copy import deepcopy
 from xml.etree import ElementTree as ET
 
-import qargparse
-
 import flame
 
 import ayon_api
 
-from ayon_core.lib import Logger, StringTemplate
+from ayon_core.lib import Logger, StringTemplate, BoolDef
 from ayon_core.pipeline import (
     LoaderPlugin,
     Creator,
@@ -567,10 +565,10 @@ class ClipLoader(LoaderPlugin):
     log = log
 
     options = [
-        qargparse.Boolean(
+        BoolDef(
             "handles",
             label="Set handles",
-            default=0,
+            default=False,
             help="Also set handles to clip as In/Out marks"
         )
     ]


### PR DESCRIPTION
## Changelog Description

Replace qargparse with attribute definitions

## Additional review information

Clean up usage of `qargparse` and starting using AYON's attribute definitons.

## Testing notes:

1. Load options should still work
