### PR TITLE
Loading workfow fixes and improvements

### DIFF
--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -6,9 +6,9 @@ import pickle
 import re
 import sys
 import tempfile
-
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
+from pathlib import Path
 from pprint import pformat
 from xml.etree import ElementTree as ET
 
@@ -802,7 +802,8 @@ class MediaInfoFile(object):
             self.log = logger
 
         # could be windows path
-        path = path.replace("\\", "/")
+        path = Path(path).as_posix()
+
         # test if `dl_get_media_info` path exists
         self._validate_media_script_path()
 
@@ -812,7 +813,6 @@ class MediaInfoFile(object):
         feed_ext = os.path.splitext(feed_basename)[1][1:].lower()
 
         with maintained_temp_file_path(".clip") as tmp_path:
-            self.log.info("Temp File: {}".format(tmp_path))
             self._generate_media_info_file(tmp_path, feed_ext, feed_dir)
 
             # get collection containing feed_basename from path

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -801,8 +801,16 @@ class MediaInfoFile(object):
         if logger:
             self.log = logger
 
-        # could be windows path
-        path = Path(path).as_posix()
+        # path could be a Windows-style path if an older project was imported
+        # into a database created by an older server version prior to migration.
+        # All current paths are stored in POSIX format, and all legacy project
+        # data has been migrated accordingly.
+        if not os.path.exists(path):
+            t_path = path.replace("\\", "/")
+            if os.path.exists(t_path):
+                path = t_path
+            else:
+                raise FileNotFoundError(f"Path does not exist: {path}")
 
         # test if `dl_get_media_info` path exists
         self._validate_media_script_path()

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
-from pathlib import Path
 from pprint import pformat
 from xml.etree import ElementTree as ET
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -801,6 +801,8 @@ class MediaInfoFile(object):
         if logger:
             self.log = logger
 
+        # could be windows path
+        path = path.replace("\\", "/")
         # test if `dl_get_media_info` path exists
         self._validate_media_script_path()
 

--- a/client/ayon_flame/api/lib.py
+++ b/client/ayon_flame/api/lib.py
@@ -801,9 +801,9 @@ class MediaInfoFile(object):
             self.log = logger
 
         # path could be a Windows-style path if an older project was imported
-        # into a database created by an older server version prior to migration.
-        # All current paths are stored in POSIX format, and all legacy project
-        # data has been migrated accordingly.
+        # into a database created by an older server version prior to
+        # migration. All current paths are stored in POSIX format, and all
+        # legacy project data has been migrated accordingly.
         if not os.path.exists(path):
             t_path = path.replace("\\", "/")
             if os.path.exists(t_path):

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -1,33 +1,28 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
-import logging
 import shutil
-from typing import Any, Optional
 from copy import deepcopy
+from typing import Any, Optional
 from xml.etree import ElementTree as ET
 
-import flame
-
 import ayon_api
-
-from ayon_core.lib import Logger, StringTemplate, BoolDef
-from ayon_core.lib.transcoding import (
-    VIDEO_EXTENSIONS,
-    IMAGE_EXTENSIONS
-)
+import flame
+from ayon_core.lib import BoolDef, Logger, StringTemplate
+from ayon_core.lib.transcoding import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 from ayon_core.pipeline import (
-    LoaderPlugin,
     Creator,
-    HiddenCreator,
     CreatorError,
+    HiddenCreator,
+    LoaderPlugin,
 )
 from ayon_core.pipeline.colorspace import get_remapped_colorspace_to_native
 from ayon_core.pipeline.context_tools import get_current_project_settings
+from ayon_core.pipeline.load import LoadError
 
 from . import lib as flib
-
 
 log = Logger.get_logger(__name__)
 
@@ -694,6 +689,15 @@ class ClipLoader(LoaderPlugin):
         """
         From a specific clip representation, load it with all of
         its versions, connecting to Flame native OpenClip version support.
+
+        Args:
+            context (dict): Context to update the container to.
+            name (str): Name of the clip to load.
+            namespace (str): Namespace of the clip to load.
+            options (dict): Options for loading the clip.
+
+        Raises:
+            LoadError: If unsupported file type is encountered.
         """
         fproject = flame.project.current_project
         self.fpd = fproject.current_workspace.desktop
@@ -782,14 +786,16 @@ class ClipLoader(LoaderPlugin):
                     representation["context"],
                     layer_rename_template,
                 )
-            except RuntimeError:
-                flame.messages.show_in_dialog(
-                    "Unsupported Input",
-                    f"Flame does not support incoming media path {path}",
-                    "warning",
-                    ["OK"],
+            except RuntimeError as exc:
+                import traceback
+                msg = (
+                    "Unsupported Input: "
+                    f"Flame does not support incoming media path {path} \n\n"
+                    f"{''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))}"
                 )
-                return
+                raise LoadError(msg) from exc
+
+
 
         version_entity = context["version"]
         clip_solver.set_current_version(
@@ -971,7 +977,7 @@ class OpenClipSolver:
     ) -> None:
         layer_uid = xml_track_data.get("uid")
         name_obj = (
-            xml_track_data.find("name")
+            xml_track_data.find("name") or xml_track_data.find("sourceName")
         )
         layer_name = name_obj.text if name_obj else None
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -788,10 +788,15 @@ class ClipLoader(LoaderPlugin):
                 )
             except RuntimeError as exc:
                 import traceback
+                trcbck_txt = "".join(
+                    traceback.format_exception(
+                        type(exc), exc, exc.__traceback__
+                    )
+                )
                 msg = (
                     "Unsupported Input: "
                     f"Flame does not support incoming media path {path} \n\n"
-                    f"{''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))}"
+                    f"{trcbck_txt}"
                 )
                 raise LoadError(msg) from exc
 

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -787,16 +787,9 @@ class ClipLoader(LoaderPlugin):
                     layer_rename_template,
                 )
             except RuntimeError as exc:
-                import traceback
-                trcbck_txt = "".join(
-                    traceback.format_exception(
-                        type(exc), exc, exc.__traceback__
-                    )
-                )
                 msg = (
                     "Unsupported Input: "
-                    f"Flame does not support incoming media path {path} \n\n"
-                    f"{trcbck_txt}"
+                    f"Flame does not support incoming media path {path}"
                 )
                 raise LoadError(msg) from exc
 


### PR DESCRIPTION
## Changelog Description
- Improving the workfow for situation where data are published at windows platform but needs to be loaded at Linux or MacOS. 
- adding user facing communication about unsupported files

## Testing notes:
1. Publish data into a testing project from Windows platform so you do have backward slashes in the representation path
2. load into Flame and see that you do not get any error raise. 
3. Load any mov unsupported codec representation
4. see that message will popup with Unsupported file type message.  
