### PR TITLE
YN-0859 Read host context from current batch when possible.

### DIFF
--- a/client/ayon_flame/api/__init__.py
+++ b/client/ayon_flame/api/__init__.py
@@ -90,6 +90,8 @@ from .batch_utils import (
     read_node_metadata,
     write_node_metadata,
     clear_node_metadata,
+    get_metadata_node,
+    get_current_batch,
 )
 
 __all__ = [
@@ -180,6 +182,8 @@ __all__ = [
     "add_reels_to_batch",
     "edit_batch_group_content",
     "get_batch_from_workspace",
+    "get_current_batch",
+    "get_metadata_node",
     "save_batch_as_consolidated_json",
     "load_batch_from_consolidated_json",
     "read_node_metadata",

--- a/client/ayon_flame/api/batch_utils.py
+++ b/client/ayon_flame/api/batch_utils.py
@@ -15,6 +15,9 @@ log = Logger.get_logger(__name__)
 # Helps to identify AYON-managed nodes.
 AYON_NOTE_MARKER = "__ayon__"
 
+# Name of the hidden Note node used to embed instance data inside the batch.
+_METADATA_NODE_NAME = "AYON_metadata"
+
 
 def read_node_metadata(node: flame.PyNode) -> Optional[Dict[str, Any]]:
     """ Read AYON instance data from a node's note attribute.
@@ -228,6 +231,36 @@ def save_batch_as_consolidated_json(
             tmp.cleanup()
 
     return filepath
+
+
+def get_current_batch() -> flame.PyBatch:
+    """ Return the current flame.batch object or None.
+    """
+    try:
+        return flame.batch
+    except Exception as error:
+        raise RuntimeError(
+            "Cannot find current batch from context."
+        ) from error
+
+
+def get_metadata_node(
+        batch: Optional[flame.PyBatch] = None,
+        create: bool = False
+    ) -> Optional[flame.PyNode]:
+    """ Find or create the AYON metadata Note node in the current batch.
+    """
+    batch = batch or get_current_batch()
+    for node in batch.nodes:
+        if node.name.get_value() == _METADATA_NODE_NAME:
+            return node
+
+    if not create:
+        return None
+
+    node = batch.create_node("Note")
+    node.name.set_value(_METADATA_NODE_NAME)
+    return node
 
 
 def load_batch_from_consolidated_json(

--- a/client/ayon_flame/api/pipeline.py
+++ b/client/ayon_flame/api/pipeline.py
@@ -24,6 +24,7 @@ from .lib import (
     maintained_segment_selection,
     set_clip_data_marker,
     set_segment_data_marker,
+    CTX,
 )
 
 PLUGINS_DIR = os.path.join(FLAME_ADDON_ROOT, "plugins")
@@ -50,11 +51,37 @@ class FlameHost(HostBase, ILoadHost, IPublishHost):
         install()
 
     def get_context_data(self):
+        """required by IPublishHost"""
         return deepcopy(self._publish_context_data)
 
     def update_context_data(self, data, changes):
+        """required by IPublishHost"""
         self._publish_context_data = deepcopy(data)
 
+    def get_current_context(self):
+        current_ctx = super().get_current_context()
+
+        # Flame can be used as a multi-workfile host.
+        # When working with batch, we try to get the
+        # current context from the batch metadata.
+        if CTX.context == "FlameMenuBatch":
+            import ayon_flame.api as flapi
+            metadata_node = flapi.get_metadata_node()
+            if metadata_node:
+                data = flapi.read_node_metadata(metadata_node)
+                try:
+                    return {
+                        "project_name": current_ctx["project_name"],
+                        "folder_path": data["folderPath"],
+                        "task_name": data["task"]
+                    }
+                except (KeyError, TypeError) as error:
+                    log.warning(
+                        "Could not read context from batch metadata: %r",
+                        error
+                    )
+
+        return current_ctx
 
 def install():
     pyblish.register_host("flame")

--- a/client/ayon_flame/plugins/create/create_batch.py
+++ b/client/ayon_flame/plugins/create/create_batch.py
@@ -2,17 +2,11 @@
 
 Will create a new workfile instance from current batch.
 """
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple
 
 from ayon_core.pipeline import CreatedInstance
 
 import ayon_flame.api as flapi
-
-import flame
-
-
-# Name of the hidden Note node used to embed instance data inside the batch.
-_METADATA_NODE_NAME = "AYON_metadata"
 
 
 class CreateBatchWorkfile(flapi.FlameCreator):
@@ -36,45 +30,16 @@ Publishing batch from Batch panel.
         # Only active in Batch context.
         self.enabled = (flapi.CTX.context == "FlameMenuBatch")
 
-    @staticmethod
-    def _get_current_batch() -> flame.PyBatch:
-        """ Return the current flame.batch object or None.
-        """
-        try:
-            return flame.batch
-        except Exception as error:
-            raise RuntimeError(
-                "Cannot find current batch from context."
-            ) from error
-
-    def _get_metadata_node(
-            self,
-            create: bool = True
-        ) -> Optional[flame.PyNode]:
-        """ Find or create the AYON metadata Note node in the current batch.
-        """
-        batch = self._get_current_batch()
-        for node in batch.nodes:
-            if node.name.get_value() == _METADATA_NODE_NAME:
-                return node
-
-        if not create:
-            return None
-
-        node = batch.create_node("Note")
-        node.name.set_value(_METADATA_NODE_NAME)
-        return node
-
     def _dump_instance_data(self, data: Dict[str, Any]):
         """ Write instance data into the batch metadata Note node.
         """
-        node = self._get_metadata_node()
+        node = flapi.get_metadata_node(create=True)
         flapi.write_node_metadata(node, data)
 
     def _load_instance_data(self) -> Dict[str, Any]:
         """ Read instance data from the batch metadata Note node.
         """
-        node = self._get_metadata_node(create=False)
+        node = flapi.get_metadata_node()
         if not node:
             return {}
 
@@ -97,7 +62,7 @@ Publishing batch from Batch panel.
         instance_data["flame_context"] = flapi.CTX.context
 
         try:
-            batch = self._get_current_batch()
+            batch = flapi.get_current_batch()
         except RuntimeError:
             self.log.warning("No active batch group found, skipping.")
             return
@@ -147,6 +112,6 @@ Publishing batch from Batch panel.
         for instance in instances:
             self._remove_instance_from_context(instance)
 
-        node = self._get_metadata_node(create=False)
+        node = flapi.get_metadata_node()
         if node:
             node.delete()


### PR DESCRIPTION
## Changelog Description

Fixes: #131 
Flame can be used as a multi-workfile host. Meaning Flame get opened from a central context but then load multiple batch (node graph) from multiple child context.

This change make the host read context from current batch if possible.
This way creator/loader/workfile get initialize with batch context.

## Testing notes:
1. Create and publish a batch group 
2. Re-open Flame from a different context and load the batch
3. Ensure when it batch context, the creator/loader/workfile context is set to the batch context
