### PR TITLE
YN-0861 Implement version sync between batch renders and batch workfile.

### DIFF
--- a/client/ayon_flame/plugins/publish/collect_batch_instance.py
+++ b/client/ayon_flame/plugins/publish/collect_batch_instance.py
@@ -1,0 +1,30 @@
+""" Collect batch instance from current Flame context.
+"""
+import pyblish.api
+
+import ayon_flame.api as flapi
+
+
+class CollectBatchInstance(pyblish.api.InstancePlugin):
+    """Collect batch render instances and handle the review attribute."""
+
+    order = pyblish.api.CollectorOrder - 0.48
+    label = "Collect Batch instance"
+    families = ["workfile"]
+    hosts = ["flame"]
+
+    def process(self, instance):
+        if instance.data.get("batch_name") is None:
+            self.log.info(
+                "Instance is not a batch workfile, skipping."
+            )
+            return
+
+        batch_name = instance.data["batch_name"]
+        batch = flapi.get_batch_from_workspace(batch_name)
+        if not batch:
+            raise ValueError(f"Batch group not found: {batch_name}")
+
+        instance.data["version"] = batch.current_iteration_number
+        instance.data["followWorkfileVersion"] = False
+        self.log.debug(f"Collected batch version: {instance.data['version']}")

--- a/client/ayon_flame/plugins/publish/collect_batch_version.py
+++ b/client/ayon_flame/plugins/publish/collect_batch_version.py
@@ -1,0 +1,32 @@
+import pyblish.api
+
+import ayon_flame.api as flapi
+
+
+class CollectBatchVersion(pyblish.api.ContextPlugin):
+    """ Collect "version" from current batch if any.
+    """
+
+    order = pyblish.api.CollectorOrder
+    label = "Collect Batch Version"
+    hosts = ["flame"]
+
+    def process(self, context):
+        # No need to collect current batch version as "workfile"
+        # version if no instance related to batch is found in context.
+        for instance in context:
+            if instance.data.get("flame_context") == "FlameMenuBatch":
+                break
+        else:
+            self.log.debug("No instances related to batch found in context.")
+            return
+
+        # Flame batch as its own iteration management,
+        # Note that current iteration might or might not
+        # have been published through AYON.
+        batch = flapi.get_current_batch()
+        context.data["version"] = batch.current_iteration_number
+        self.log.debug(
+            f"Collected context version: {context.data['version']} "
+            f"from batch"
+        )


### PR DESCRIPTION
## Changelog Description

Fixes: #134 

Changes:
* [X] Batch `workfile` products now always follow Flame's internal iteration number
* [X] Add a collect plugin to leverage `ayon-core`'s `CollectAnatomyInstanceData.follow_workfile_version` feature with Flame batch `render`and batch `workfile`

## Additional review information

## Testing notes:

Batch workfile versioning
1. Publish new `workfile` from batch
2. Ensure that the resulting product version always match the Flame batch iteration

Batch workfile / Batch render sync
1. Enable `ayon+settings://core/publish/CollectAnatomyInstanceData/follow_workfile_version` setting
2. Ensure that batch `render` product always match the Flame batch iteration
