### PR TITLE
YN-0862: Implement Batch render metadata on Write File nodes.

### DIFF
--- a/client/ayon_flame/plugins/create/create_batch_render.py
+++ b/client/ayon_flame/plugins/create/create_batch_render.py
@@ -1,7 +1,7 @@
 """Creates a render product instance per selected Write File node,
 storing instance metadata directly in the node's note attribute.
 """
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 
 from ayon_core.lib import BoolDef
 from ayon_core.pipeline import CreatedInstance, CreatorError
@@ -31,6 +31,10 @@ current batch group.
 
     def apply_settings(self, project_settings):
         super().apply_settings(project_settings)
+
+        create_settings = project_settings["flame"]["create"]
+        self.write_node_presets = create_settings[self.__class__.__name__]
+
         # Only active in Batch context.
         self.enabled = (flapi.CTX.context == "FlameMenuBatch")
 
@@ -41,6 +45,55 @@ current batch group.
         return [
             node for node in selected
             if isinstance(node, flame.PyWriteFileNode)
+        ]
+
+    @staticmethod
+    def _connect_clip_and_write_nodes(
+        clip_node: flame.PyClipNode,
+        write_node: flame.PyWriteFileNode,
+    ):
+        duration = clip_node.duration
+        write_node.source_timecode = clip_node.clip.start_time
+
+        start_frame = flame.batch.start_frame.get_value()
+        write_node.range_start = start_frame
+        write_node.range_end = start_frame + duration - 1
+
+        flame.batch.connect_nodes(
+            clip_node,
+            clip_node.output_sockets[0], # rgb
+            write_node,
+            "Front",
+        )
+
+    def _apply_metadata_on_write_node(
+        self,
+        write_node: flame.PyWriteFileNode,
+        node_name: Optional[str] = None,
+    ):
+        if node_name:
+            write_node.name = node_name
+
+        for attr, value in self.write_node_presets.items():
+            if attr == "node_name":
+                continue
+
+            if value not in (None, ""):
+                try:
+                    setattr(write_node, attr, value)
+                except RuntimeError as error:
+                    raise RuntimeError(
+                        f"Could not set attribute '{attr}' "
+                        f"value '{value}' on Write File node."
+                    ) from error
+
+    def get_pre_create_attr_defs(self) -> List[BoolDef]:
+        return [
+            BoolDef(
+                "use_selection",
+                default=True,
+                label="Use Selection"
+            )
         ]
 
     def get_instance_attr_defs(self) -> List[BoolDef]:
@@ -61,37 +114,57 @@ current batch group.
         """Create a render instance for each selected Write File node."""
         instance_data["flame_context"] = flapi.CTX.context
 
-        nodes = self._get_write_file_nodes()
-        if not nodes:
-            raise CreatorError("No 'Write File' nodes found from selection.")
+        use_selection = pre_create_data["use_selection"]
+        selected = flame.batch.selected_nodes.get_value()
 
+        if use_selection and not selected:
+            raise CreatorError("No nodes selected from batch.")
+
+        if use_selection and len(selected) > 1:
+            raise CreatorError("Multiple selected nodes.")
+
+        nodes = self._get_write_file_nodes()
         if len(nodes) > 1:
             # TODO: How to handle multiple selected 'Write File' nodes ?
             # Currently they'd all produce the same product name.
             raise CreatorError("Multiple selected 'Write File' nodes.")
 
+        if nodes:
+            node = nodes[0]
+        else:
+            node = flame.batch.create_node("Write File")
+
         batch_name = flame.batch.name.get_value()
 
-        for node in nodes:
-            node_name = node.name.get_value()
+        # Apply setting metadata on the write node
+        self._apply_metadata_on_write_node(
+            node,
+            node_name=self.write_node_presets.get("node_name"),
+        )
 
-            node_instance_data = dict(instance_data)
-            node_instance_data["batch_name"] = batch_name
-            node_instance_data["write_node_name"] = node_name
+        # Attempt to connect to select "Clip" node if exists
+        selected_node = selected[0] if selected else None
+        if selected_node and isinstance(selected_node, flame.PyClipNode):
+            self._connect_clip_and_write_nodes(selected_node, node)
 
-            instance = CreatedInstance(
-                product_base_type=self.product_base_type,
-                product_type=self.product_type,
-                product_name=product_name,
-                data=node_instance_data,
-                creator=self,
-            )
-            self._add_instance_to_context(instance)
-            flapi.write_node_metadata(node, instance.data_to_store())
-            self.log.info(
-                f"Created render instance '{product_name}' "
-                f"from node '{node_name}'."
-            )
+        node_name = node.name.get_value()
+        node_instance_data = dict(instance_data)
+        node_instance_data["batch_name"] = batch_name
+        node_instance_data["write_node_name"] = node_name
+
+        instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=product_name,
+            data=node_instance_data,
+            creator=self,
+        )
+        self._add_instance_to_context(instance)
+        flapi.write_node_metadata(node, instance.data_to_store())
+        self.log.info(
+            f"Created render instance '{product_name}' "
+            f"from node '{node_name}'."
+        )
 
     def collect_instances(self):
         """ Collect existing instances from Write File node metadata. """

--- a/server/settings/create_plugins.py
+++ b/server/settings/create_plugins.py
@@ -151,6 +151,46 @@ class CollectShotClipInstancesModels(BaseSettingsModel):
         )
     )
 
+
+class BatchWriteFileModel(BaseSettingsModel):
+    node_name: str = SettingsField(
+        "node_name",
+        title="Node name",
+    )
+    media_path: str = SettingsField(
+        "media_path",
+        title="Media path",
+    )
+    frame_padding: int = SettingsField(
+        "frame_padding",
+        title="Frame padding",
+    )
+    compress_mode: str = SettingsField(
+        "compress_mode",
+        title="Compress mode",
+    )
+    include_setup: bool = SettingsField(
+        "include_setup",
+        title="Include setup",
+    )
+    include_setup_path: str = SettingsField(
+        "include_setup_path",
+        title="Include setup path",
+    )
+    create_clip: bool = SettingsField(
+        "create_clip",
+        title="Create clip",
+    )
+    shot_name: str = SettingsField(
+        "shot_name",
+        title="Shot name",
+    )
+    media_path_pattern: str = SettingsField(
+        "media_path_pattern",
+        title="Media path pattern",
+    )
+
+
 class CreatePluginsModel(BaseSettingsModel):
     CreateShotClip: CreateShotClipModel = SettingsField(
         default_factory=CreateShotClipModel,
@@ -159,6 +199,10 @@ class CreatePluginsModel(BaseSettingsModel):
     CollectShotClip: CollectShotClipInstancesModels = SettingsField(
         default_factory=CollectShotClipInstancesModels,
         title="Collect Shot Clip instances"
+    )
+    CreateBatchRender: BatchWriteFileModel = SettingsField(
+        default_factory=BatchWriteFileModel,
+        title="Create Batch Render"
     )
 
 
@@ -213,5 +257,19 @@ DEFAULT_CREATE_SETTINGS = {
     },
     "CollectShotClip": {
         "collectSelectedInstance": False,
-    }
+    },
+    "CreateBatchRender": {
+        "node_name": "RenderFlame",
+        "media_path": "",
+        "frame_padding": 4,
+        "compress_mode": "DWAA",
+        "include_setup": True,
+        "include_setup_path": "<batch name>_flame_v<iteration###>",
+        "create_clip": False,
+        "shot_name": "<batch name>",
+        "media_path_pattern": (
+            "renders/flame/<name>/v<iteration###>/"
+            "<batch name><name>_v<iteration###>"
+        ),
+    },
 }


### PR DESCRIPTION
## Changelog Description

Fixes: #133 
Changes:
* [X] Add new settings to be set on `Write File` node through batch `render` product
* [X] Add a `use_selection` pre-create attribute for batch render creator

## Testing notes:
1. Package and install current addon
2. Adjust some settings under `ayon+settings://flame/create/CreateBatchRender` if needed
3. Open Flame and use the `Batch render` creator from Batch UI
4. Ensure that expected metadata set in settings are reported on new `Write File` node
