### PR TITLE
YN-0860 Add one-click publish script

### DIFF
--- a/client/ayon_flame/scripts/publish_current_batch_content.py
+++ b/client/ayon_flame/scripts/publish_current_batch_content.py
@@ -1,28 +1,8 @@
 """ Publish current content without opening the UI.
 """
-from qtpy import QtWidgets
-
 from ayon_core.tools.publisher.control import PublisherController
 
-
 import ayon_flame.api as ayfapi
-
-
-_MAIN_WINDOW = None
-
-
-def _get_main_window():
-    global _MAIN_WINDOW
-    if _MAIN_WINDOW is None:
-        _MAIN_WINDOW = next(
-            (
-                obj
-                for obj in QtWidgets.QApplication.topLevelWidgets()
-                if isinstance(obj, QtWidgets.QMainWindow)
-            ),
-            None
-        )
-    return _MAIN_WINDOW
 
 
 def publish_current_batch_content():

--- a/client/ayon_flame/scripts/publish_current_batch_content.py
+++ b/client/ayon_flame/scripts/publish_current_batch_content.py
@@ -1,0 +1,61 @@
+""" Publish current content without opening the UI.
+"""
+from qtpy import QtWidgets
+
+from ayon_core.tools.utils.host_tools import (
+    get_tool_by_name,
+    show_publisher,
+)
+
+import ayon_flame.api as ayfapi
+
+
+_MAIN_WINDOW = None
+
+
+def _get_main_window():
+    global _MAIN_WINDOW
+    if _MAIN_WINDOW is None:
+        _MAIN_WINDOW = next(
+            (
+                obj
+                for obj in QtWidgets.QApplication.topLevelWidgets()
+                if isinstance(obj, QtWidgets.QMainWindow)
+            ),
+            None
+        )
+    return _MAIN_WINDOW
+
+
+def publish_current_batch_content():
+    """ Publish the current batch content.
+    """
+    ayfapi.CTX.context = "FlameMenuBatch"
+
+    show_publisher(
+        tab="publish",
+        parent=_get_main_window()
+    )
+    window = get_tool_by_name("publisher")
+    window.set_current_tab("publish")
+    controller = window.controller
+
+    def on_ready_to_publish(_=None):
+        # Limit callback execution to this first call only.
+        if getattr(on_ready_to_publish, "done", False):
+            return  # already executed
+        on_ready_to_publish.done = True
+
+        controller.save_changes()
+        if not controller.publish_is_running():
+            controller.publish()
+
+    if window.isVisible() and not window._reset_on_show:
+        on_ready_to_publish()
+    else:
+        controller.register_event_callback(
+            "controller.reset.finished",
+            on_ready_to_publish
+        )
+
+    window.hide()

--- a/client/ayon_flame/scripts/publish_current_batch_content.py
+++ b/client/ayon_flame/scripts/publish_current_batch_content.py
@@ -2,10 +2,8 @@
 """
 from qtpy import QtWidgets
 
-from ayon_core.tools.utils.host_tools import (
-    get_tool_by_name,
-    show_publisher,
-)
+from ayon_core.tools.publisher.control import PublisherController
+
 
 import ayon_flame.api as ayfapi
 
@@ -32,30 +30,6 @@ def publish_current_batch_content():
     """
     ayfapi.CTX.context = "FlameMenuBatch"
 
-    show_publisher(
-        tab="publish",
-        parent=_get_main_window()
-    )
-    window = get_tool_by_name("publisher")
-    window.set_current_tab("publish")
-    controller = window.controller
-
-    def on_ready_to_publish(_=None):
-        # Limit callback execution to this first call only.
-        if getattr(on_ready_to_publish, "done", False):
-            return  # already executed
-        on_ready_to_publish.done = True
-
-        controller.save_changes()
-        if not controller.publish_is_running():
-            controller.publish()
-
-    if window.isVisible() and not window._reset_on_show:
-        on_ready_to_publish()
-    else:
-        controller.register_event_callback(
-            "controller.reset.finished",
-            on_ready_to_publish
-        )
-
-    window.hide()
+    controller = PublisherController()
+    controller.reset()
+    controller.publish()


### PR DESCRIPTION
## Changelog Description

Add a custom script to run a batch publish from one-click.
This is part of #138 request.

## Testing notes:
0. Prepare a batch with some created instances
1. Pase this settings in Flame `ayon+settings://flame/scriptsmenu` settings:
```
{
  "name": "Custom Tools",
  "enabled": true,
  "definitions": [
    {
      "title": "Publish current batch",
      "command": "from ayon_flame.scripts import publish_current_batch_content; publish_current_batch_content.publish_current_batch_content()",
      "flame_context": "FlameMenuBatch"
    }
  ]
}
```
2. From the batch context menu, trigger the publish:
<img width="1085" height="767" alt="image" src="https://github.com/user-attachments/assets/507b37df-3605-495b-b9db-e1c7af670213" />
