### PR TITLE
Remove `Library...` button from AYON Menus.

### DIFF
--- a/client/ayon_flame/api/menu.py
+++ b/client/ayon_flame/api/menu.py
@@ -121,10 +121,6 @@ class FlameMenuProjectConnect(_FlameMenuApp):
             "name": "1 - Load...",
             "execute": lambda x: self.tools_helper.show_loader()
         })
-        menu['actions'].append({
-            "name": "2 - Library...",
-            "execute": lambda x: self.tools_helper.show_library_loader()
-        })
 
         return menu
 
@@ -172,10 +168,6 @@ class FlameMenuTimeline(_FlameMenuApp):
         #     "name": "Manage...",
         #     "execute": lambda x: self.tools_helper.show_scene_inventory()
         # })
-        menu['actions'].append({
-            "name": "4 - Library...",
-            "execute": lambda x: self.tools_helper.show_library_loader()
-        })
 
         return menu
 
@@ -222,10 +214,6 @@ class FlameMenuBatch(_FlameMenuApp):
                 context="FlameMenuBatch"
             )
         })
-        menu['actions'].append({
-            "name": "4 - Library...",
-            "execute": lambda x: self.tools_helper.show_library_loader()
-        })
 
         return menu
 
@@ -270,10 +258,6 @@ class FlameMenuUniversal(_FlameMenuApp):
                 self.tools_helper.show_loader,
                 context="FlameMenuUniversal"
             )
-        })
-        menu['actions'].append({
-            "name": "4 - Library...",
-            "execute": lambda x: self.tools_helper.show_library_loader()
         })
 
         return menu


### PR DESCRIPTION
## Changelog Description
- Remove `Library...` button from AYON Menus.

## Additional Info
`Library` functionality was merged sometime ago with `load` tool. 
And it's no longer needed to exist in the menu.

## Testing notes:
1. `Library...` button no longer exists in the menu.

Resolve #140 