### PR TITLE
Chore: Use new editorial families

### DIFF
--- a/client/ayon_flame/plugins/publish/collect_plate_from_reel.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_reel.py
@@ -26,7 +26,15 @@ class CollectReelPlate(pyblish.api.InstancePlugin):
             return
 
         # Adjust instance families
-        instance.data["families"].append("clip")
+        instance.data["families"].extend([
+            "clip",
+            # Mark for 'CollectOTIORanges' in core
+            "otio.clip.ranges",
+            # Mark for 'CollectOTIOReviewTrack' in core
+            "otio.review.track",
+            # Mark for 'CollectOTIOProductResources' in core
+            "otio.clip.resources",
+        ])
         if instance.data["creator_attributes"].get("review"):
             instance.data["families"].append("review")
 

--- a/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
@@ -56,7 +56,7 @@ class CollectTimelinePlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
-                # Tell 'CollectOTIOReviewClips' to use the current clip
+                # Tell 'CollectOTIOReviewTrack' to use the current clip
                 instance.data["otioReviewClips"] = [otio_clip]
                 instance.data.pop("reviewTrack", None)
             else:

--- a/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
@@ -26,7 +26,15 @@ class CollectTimelinePlate(pyblish.api.InstancePlugin):
             self.log.debug("Current plate instance is not part of a timeline.")
             return
 
-        instance.data["families"].append("clip")
+        instance.data["families"].extend([
+            "clip",
+            # Mark for 'CollectOTIORanges' in core
+            "otio.clip.ranges",
+            # Mark for 'CollectOTIOReviewTrack' in core
+            "otio.review.track",
+            # Mark for 'CollectOTIOProductResources' in core
+            "otio.clip.resources",
+        ])
 
         # Adjust instance data from parent otio timeline.
         otio_timeline = instance.context.data["otioTimeline"]

--- a/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
+++ b/client/ayon_flame/plugins/publish/collect_plate_from_timeline.py
@@ -56,6 +56,8 @@ class CollectTimelinePlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
+                # Tell 'CollectOTIOReviewClips' to use the current clip
+                instance.data["otioReviewClips"] = [otio_clip]
                 instance.data.pop("reviewTrack", None)
             else:
                 instance.data["reviewTrack"] = reviewable_source

--- a/client/ayon_flame/plugins/publish/collect_shots.py
+++ b/client/ayon_flame/plugins/publish/collect_shots.py
@@ -57,6 +57,8 @@ class CollectShot(pyblish.api.InstancePlugin):
         Args:
             instance (obj): The publishing instance.
         """
+        # Mark for 'CollectOTIORanges' in core
+        instance.data["families"].append("otio.clip.ranges")
         context = instance.context
         instance_id = instance.data["instance_id"]
 


### PR DESCRIPTION
## Changelog Description
Use new families defined in core to process editorial instances.

## Additional review information
[This PR](https://github.com/ynput/ayon-core/pull/1967) in ayon core is adding new families that are used to explicitly process instances instead of host based processing.

This PR is adding the families but should still work with old core. The same the core PR should work with hiero develop.

## Testing notes:
All possible combinations of ayon-core and ayon-hiero should produce exactly same output.
- flame develop + core develop
- flame PR + core PR
- flame PR + core develop
- flame develop + core PR