### PR TITLE
Fix project creation from prehook in Flame >= 2026 and consolidate WireTap interface

### DIFF
--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -75,31 +75,15 @@ class WireTapCom(object):
             project_data (dict): Flame compatible project data
             user_name (str): name of user
 
-        Keyword Args:
-            workspace_name (str): name of workspace
-            color_policy (str): colour policy name, before flame 2026
-            ocio_config_path (str): OCIO config path, flame 2026 and above
-
         Returns:
             list: arguments
         """
 
         workspace_name = kwargs.get("workspace_name")
         color_policy = kwargs.get("color_policy")
-        ocio_config_path = kwargs.get("ocio_config_path")
 
         project_exists = self._project_prep(project_name)
         if not project_exists:
-            # colour management is only set on a new project
-            if self._get_flame_year() >= 2026:
-                if ocio_config_path:
-                    project_data["OCIOConfigFile"] = ocio_config_path
-                else:
-                    print(
-                        "WARNING: no OCIO config resolved, '{}' is created "
-                        "with flame's default config.".format(project_name)
-                    )
-
             self._set_project_settings(project_name, project_data)
             self._set_project_colorspace(project_name, color_policy)
 
@@ -153,9 +137,7 @@ class WireTapCom(object):
         return self._flame_year
 
     def _workspace_prep(self, project_name, workspace_name):
-        """Preparing a workspace
-
-        In case it doesn not exists it will create one
+        """Prepare a workspace, create it if needed.
 
         Args:
             project_name (str): project name
@@ -183,12 +165,11 @@ class WireTapCom(object):
                 )
 
         print(
-            "Workspace `{}` is successfully created".format(workspace_name))
+            "Workspace `{}` is successfully created".format(workspace_name)
+        )
 
     def _project_prep(self, project_name):
-        """Preparing a project
-
-        In case it doesn not exists it will create one
+        """Prepare a project, create it needed.
 
         Args:
             project_name (str): project name
@@ -502,20 +483,14 @@ class WireTapCom(object):
     def _set_project_colorspace(self, project_name, color_policy):
         """Set project's colorspace policy.
 
-        A policy which cannot be applied is reported but not raised, the
-        project stays usable with the default policy and it can be changed
-        from the flame UI.
-
         Args:
             project_name (str): name of project
             color_policy (str): name of policy
-        """
-        # flame 2026 uses OCIO configs, not syncolor anymore
-        if self._get_flame_year() >= 2026:
-            print("Skipping colour policy '{}', flame 2026 uses OCIO".format(
-                color_policy))
-            return
 
+        Raise:
+            RuntimeError: Not able to set colorspace policy.
+
+        """
         color_policy = color_policy or "Legacy"
 
         # check if the colour policy in custom dir
@@ -550,7 +525,7 @@ class WireTapCom(object):
         )
 
         if exit_code != 0:
-            print("Cannot set colorspace {} on project {}".format(
+            RuntimeError("Cannot set colorspace {} on project {}".format(
                 color_policy, project_name
             ))
 

--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -487,8 +487,8 @@ class WireTapCom(object):
             project_name (str): name of project
             color_policy (str): name of policy
 
-        Raise:
-            RuntimeError: Not able to set colorspace policy.
+        Raises:
+            RuntimeError: Not able to set colorspace policy
 
         """
         color_policy = color_policy or "Legacy"

--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -19,10 +19,6 @@ from adsk.libwiretapPythonClientAPI import (  # noqa
 )
 
 
-# project attributes which flame 2026 resolves itself at project creation
-LEGACY_PROJECT_ATTRIBUTES = ("SetupDir",)
-
-
 class WireTapCom(object):
     """
     Comunicator class wrapper for talking to WireTap db.
@@ -41,25 +37,32 @@ class WireTapCom(object):
             volume_name (str, optional): Name of volume. Defaults to None.
             group_name (str, optional): Name of user group. Defaults to None.
         """
-        # set main attributes of server
-        # if there are none set the default installation
-        self.host_name = host_name or "localhost"
-        self.volume_name = volume_name or "stonefs"
-        # without a group the created nodes keep the current user group
-        self.group_name = group_name
+        self._flame_version = None
 
         # wiretap tools dir path
         self.wiretap_tools_dir = os.getenv("AYON_WIRETAP_TOOLS")
-
-        self._flame_year = None
+        self.host_name = host_name or "localhost"
 
         # initialize WireTap client
         WireTapClientInit()
-
-        # add the server to shared variable
         self._server = WireTapServerHandle("{}:IFFFS".format(self.host_name))
-        print("WireTap connected at '{}'...".format(
-            self.host_name))
+        if not self._server.ping():
+            raise RuntimeError(
+                "Failed to ping WireTap server, check host: {}".format(
+                    self.host_name
+                )
+            )
+
+        print("WireTap connected at '{}'...".format(self.host_name))
+
+        # Stone+Wire (Flame < 2026)
+        # Default to installation values.
+        if self._get_flame_version()[0] < 2026:
+            self.volume_name = volume_name or "stonefs"
+            self.group_name = group_name or "staff"
+        else:
+            self.volume_name = None  # no volumes in Flame>2026
+            self.group_name = group_name  # current user group if None
 
     def close(self):
         self._server = None
@@ -68,7 +71,7 @@ class WireTapCom(object):
 
     def get_launch_args(
             self, project_name, project_data, user_name, **kwargs):
-        """Forming launch arguments for AYON launcher.
+        """Return Flame launch arguments to be used by AYON launcher.
 
         Args:
             project_name (str): name of project
@@ -93,7 +96,7 @@ class WireTapCom(object):
         ]
 
         # user profiles have been removed in flame 2025
-        if self._get_flame_year() < 2025:
+        if self._get_flame_version()[0] < 2025:
             user_name = self._user_prep(user_name)
             launch_args.append("--start-user={}".format(user_name))
 
@@ -104,28 +107,29 @@ class WireTapCom(object):
 
         else:
             print("Using a custom workspace '{}'".format(workspace_name))
-
             self._workspace_prep(project_name, workspace_name)
             launch_args.append("--start-workspace={}".format(workspace_name))
             return launch_args
 
-    def _get_flame_year(self):
-        """Get the flame release year.
+    def _get_flame_version(self):
+        """Get the flame version.
 
         Returns:
             int: The flame year, e.g. 2025
+            int: The flame minor version, e.g. 2
 
         Raises:
-            AttributeError: unable to retrieve the flame version number.
+            AttributeError: unable to retrieve the flame version.
         """
-        if self._flame_year is not None:
-            return self._flame_year
+        if self._flame_version is not None:
+            return self._flame_version
 
         version_major = WireTapInt(0)
         version_minor = WireTapInt(0)
-
         version_exists = self._server.getVersion(version_major, version_minor)
 
+        # Note: this usually happens when the wiretap server is broken
+        # due to conflicting installations. Best re-install Flame from scratch.
         if not version_exists:
             raise AttributeError(
                     "Cannot get flame version details: {}".format(
@@ -133,8 +137,8 @@ class WireTapCom(object):
                     )
                 )
 
-        self._flame_year = int(version_major)
-        return self._flame_year
+        self._flame_version = int(version_major), int(version_minor)
+        return self._flame_version
 
     def _workspace_prep(self, project_name, workspace_name):
         """Prepare a workspace, create it if needed.
@@ -189,72 +193,74 @@ class WireTapCom(object):
             print("Project '{}' already exists.".format(project_name))
             return True
 
-        if self._get_flame_year() < 2026:
-            # projects used to be created into a Stone+Wire volume
+        # Flame < 2025: Stone+Wire,
+        # create project in provided volume name
+        if self._get_flame_version()[0] < 2026:
             volumes = self._get_all_volumes()
 
             if len(volumes) == 0:
                 raise AttributeError(
-                    "Not able to create new project. No Volumes existing"
+                    "Not able to create new project: no volumes available."
+                    "Do create a volume '{}' in Flame.".format(
+                        self.volume_name
+                    )
                 )
 
             # check if volumes exists
             if self.volume_name not in volumes:
                 raise AttributeError(
-                    ("Volume '{}' does not exist in '{}'").format(
-                        self.volume_name, volumes)
+                    (
+                        "Not able to create new project: volume '{}' does not "
+                        "exist in Flame. Available volumes are: {}"
+                    ).format(self.volume_name, volumes)
                 )
 
             parent_args = ["-n", os.path.join("/volumes", self.volume_name)]
+
+        # Flame >= 2026: Postgres + filesystem
         else:
-            # volumes removed in flame 2026
             parent_args = ["-n", "/projects", "-t", "PROJECT"]
 
         # form cmd arguments
-        project_create_cmd = [
+        project_create_cmd_args = [
             os.path.join(self.wiretap_tools_dir, "wiretap_create_node")
         ]
-        project_create_cmd.extend(parent_args)
-        project_create_cmd.extend(["-d", project_name])
+        project_create_cmd_args.extend(parent_args)
+        project_create_cmd_args.extend(["-d", project_name])
 
-        group_name = self.group_name
-        if not group_name and self._get_flame_year() < 2026:
-            group_name = "staff"
+        if self.group_name:
+            project_create_cmd_args.extend(["-g", self.group_name])
 
-        if group_name:
-            project_create_cmd.extend(["-g", group_name])
-
-        print(project_create_cmd)
-
+        print(
+            "Project creation cmd line: {}".format(
+                " ".join(project_create_cmd_args)
+            )
+        )
         process = subprocess.Popen(
-            project_create_cmd,
+            project_create_cmd_args,
             cwd=os.path.expanduser('~'),
             preexec_fn=_subprocess_preexec_fn,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True
         )
-        output = process.communicate()[0]
+        output, stderr = process.communicate()
 
         if process.returncode != 0:
-            message = "Cannot create project '{}' in flame db: {}".format(
-                project_name, output.strip())
-
-            if group_name:
-                if self.group_name:
-                    group_source = "the 'FLAME_WIRETAP_GROUP' setting"
-                else:
-                    group_source = "the pre-2026 default"
-
-                message += (
-                    "\nProject group '{}' comes from {} and has to exist on "
-                    "the wiretap host.".format(group_name, group_source)
+            message = (
+                (
+                    "Cannot create project '{}' (project_group: {}) "
+                    "in Flame: {}, {}"
+                ).format(
+                    project_name,
+                    self.group_name,
+                    output.strip(),
+                    stderr.strip()
                 )
-
+            )
             raise RuntimeError(message)
 
-        print(
-            "A new project '{}' is created.".format(project_name))
+        print("New project '{}' is created.".format(project_name))
         return False
 
     def _get_all_volumes(self):
@@ -451,13 +457,18 @@ class WireTapCom(object):
         Raises:
             AttributeError: Not able to set project attributes
         """
-        if self._get_flame_year() >= 2026:
-            # keep the paths resolved at project creation time
-            project_data = {
-                key: value
-                for key, value in project_data.items()
-                if key not in LEGACY_PROJECT_ATTRIBUTES
-            }
+        flame_year, flame_minor = self._get_flame_version()
+
+        # Flame 2026.0 has an inconsistent project creation
+        # XML API (still uses SetupDir but no description field)
+        if flame_year == 2026 and flame_minor == 0:
+            project_data = project_data.copy()
+            project_data.pop("Description", None)
+
+        # No more SetupDir required from Flame 2026.1
+        elif flame_year >= 2026:
+            project_data = project_data.copy()
+            project_data.pop("SetupDir", None)
 
         # generated xml from project_data dict
         _xml = "<Project>"
@@ -489,7 +500,6 @@ class WireTapCom(object):
 
         Raises:
             RuntimeError: Not able to set colorspace policy
-
         """
         color_policy = color_policy or "Legacy"
 

--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -19,6 +19,10 @@ from adsk.libwiretapPythonClientAPI import (  # noqa
 )
 
 
+# project attributes which flame 2026 resolves itself at project creation
+LEGACY_PROJECT_ATTRIBUTES = ("SetupDir",)
+
+
 class WireTapCom(object):
     """
     Comunicator class wrapper for talking to WireTap db.
@@ -41,10 +45,13 @@ class WireTapCom(object):
         # if there are none set the default installation
         self.host_name = host_name or "localhost"
         self.volume_name = volume_name or "stonefs"
-        self.group_name = group_name or "staff"
+        # without a group the created nodes keep the current user group
+        self.group_name = group_name
 
         # wiretap tools dir path
         self.wiretap_tools_dir = os.getenv("AYON_WIRETAP_TOOLS")
+
+        self._flame_year = None
 
         # initialize WireTap client
         WireTapClientInit()
@@ -60,7 +67,7 @@ class WireTapCom(object):
         print("WireTap closed...")
 
     def get_launch_args(
-            self, project_name, project_data, user_name, *args, **kwargs):
+            self, project_name, project_data, user_name, **kwargs):
         """Forming launch arguments for AYON launcher.
 
         Args:
@@ -68,15 +75,31 @@ class WireTapCom(object):
             project_data (dict): Flame compatible project data
             user_name (str): name of user
 
+        Keyword Args:
+            workspace_name (str): name of workspace
+            color_policy (str): colour policy name, before flame 2026
+            ocio_config_path (str): OCIO config path, flame 2026 and above
+
         Returns:
             list: arguments
         """
 
         workspace_name = kwargs.get("workspace_name")
         color_policy = kwargs.get("color_policy")
+        ocio_config_path = kwargs.get("ocio_config_path")
 
         project_exists = self._project_prep(project_name)
         if not project_exists:
+            # colour management is only set on a new project
+            if self._get_flame_year() >= 2026:
+                if ocio_config_path:
+                    project_data["OCIOConfigFile"] = ocio_config_path
+                else:
+                    print(
+                        "WARNING: no OCIO config resolved, '{}' is created "
+                        "with flame's default config.".format(project_name)
+                    )
+
             self._set_project_settings(project_name, project_data)
             self._set_project_colorspace(project_name, color_policy)
 
@@ -96,8 +119,7 @@ class WireTapCom(object):
             return launch_args
 
         else:
-            print(
-                "Using a custom workspace '{}'".format(workspace_name))
+            print("Using a custom workspace '{}'".format(workspace_name))
 
             self._workspace_prep(project_name, workspace_name)
             launch_args.append("--start-workspace={}".format(workspace_name))
@@ -112,6 +134,9 @@ class WireTapCom(object):
         Raises:
             AttributeError: unable to retrieve the flame version number.
         """
+        if self._flame_year is not None:
+            return self._flame_year
+
         version_major = WireTapInt(0)
         version_minor = WireTapInt(0)
 
@@ -123,7 +148,9 @@ class WireTapCom(object):
                         self._server.lastError()
                     )
                 )
-        return int(version_major)
+
+        self._flame_year = int(version_major)
+        return self._flame_year
 
     def _workspace_prep(self, project_name, workspace_name):
         """Preparing a workspace
@@ -166,24 +193,26 @@ class WireTapCom(object):
         Args:
             project_name (str): project name
 
+        Returns:
+            bool: True if the project already existed
+
         Raises:
             AttributeError: unable to create project
+            RuntimeError: project creation command failed
         """
-        # test if projeft exists
+        # test if project exists
         project_exists = self._child_is_in_parent_path(
             "/projects", project_name, "PROJECT")
 
-        # volumes were removed in flame 2026
-        correct_flame_version = self._get_flame_year() < 2026
-
-        if not correct_flame_version:
-            # flame 2026 does not use /volumes anymore
+        if project_exists:
+            print("Project '{}' already exists.".format(project_name))
             return True
 
-        if not project_exists:
+        if self._get_flame_year() < 2026:
+            # projects used to be created into a Stone+Wire volume
             volumes = self._get_all_volumes()
 
-            if len(volumes) == 0 and correct_flame_version:
+            if len(volumes) == 0:
                 raise AttributeError(
                     "Not able to create new project. No Volumes existing"
                 )
@@ -195,35 +224,57 @@ class WireTapCom(object):
                         self.volume_name, volumes)
                 )
 
-            # form cmd arguments
-            project_create_cmd = [
-                os.path.join(
-                    self.wiretap_tools_dir,
-                    "wiretap_create_node"
-                ),
-                '-n',
-                os.path.join("/volumes", self.volume_name),
-                '-d',
-                project_name,
-                '-g',
-            ]
+            parent_args = ["-n", os.path.join("/volumes", self.volume_name)]
+        else:
+            # volumes removed in flame 2026
+            parent_args = ["-n", "/projects", "-t", "PROJECT"]
 
-            project_create_cmd.append(self.group_name)
+        # form cmd arguments
+        project_create_cmd = [
+            os.path.join(self.wiretap_tools_dir, "wiretap_create_node")
+        ]
+        project_create_cmd.extend(parent_args)
+        project_create_cmd.extend(["-d", project_name])
 
-            print(project_create_cmd)
+        group_name = self.group_name
+        if not group_name and self._get_flame_year() < 2026:
+            group_name = "staff"
 
-            exit_code = subprocess.call(
-                project_create_cmd,
-                cwd=os.path.expanduser('~'),
-                preexec_fn=_subprocess_preexec_fn
-            )
+        if group_name:
+            project_create_cmd.extend(["-g", group_name])
 
-            if exit_code != 0:
-                RuntimeError("Cannot create project in flame db")
+        print(project_create_cmd)
 
-            print(
-                "A new project '{}' is created.".format(project_name))
-        return project_exists
+        process = subprocess.Popen(
+            project_create_cmd,
+            cwd=os.path.expanduser('~'),
+            preexec_fn=_subprocess_preexec_fn,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True
+        )
+        output = process.communicate()[0]
+
+        if process.returncode != 0:
+            message = "Cannot create project '{}' in flame db: {}".format(
+                project_name, output.strip())
+
+            if group_name:
+                if self.group_name:
+                    group_source = "the 'FLAME_WIRETAP_GROUP' setting"
+                else:
+                    group_source = "the pre-2026 default"
+
+                message += (
+                    "\nProject group '{}' comes from {} and has to exist on "
+                    "the wiretap host.".format(group_name, group_source)
+                )
+
+            raise RuntimeError(message)
+
+        print(
+            "A new project '{}' is created.".format(project_name))
+        return False
 
     def _get_all_volumes(self):
         """Request all available volumens from WireTap
@@ -419,6 +470,14 @@ class WireTapCom(object):
         Raises:
             AttributeError: Not able to set project attributes
         """
+        if self._get_flame_year() >= 2026:
+            # keep the paths resolved at project creation time
+            project_data = {
+                key: value
+                for key, value in project_data.items()
+                if key not in LEGACY_PROJECT_ATTRIBUTES
+            }
+
         # generated xml from project_data dict
         _xml = "<Project>"
         for key, value in project_data.items():
@@ -443,13 +502,20 @@ class WireTapCom(object):
     def _set_project_colorspace(self, project_name, color_policy):
         """Set project's colorspace policy.
 
+        A policy which cannot be applied is reported but not raised, the
+        project stays usable with the default policy and it can be changed
+        from the flame UI.
+
         Args:
             project_name (str): name of project
             color_policy (str): name of policy
-
-        Raises:
-            RuntimeError: Not able to set colorspace policy
         """
+        # flame 2026 uses OCIO configs, not syncolor anymore
+        if self._get_flame_year() >= 2026:
+            print("Skipping colour policy '{}', flame 2026 uses OCIO".format(
+                color_policy))
+            return
+
         color_policy = color_policy or "Legacy"
 
         # check if the colour policy in custom dir
@@ -484,7 +550,7 @@ class WireTapCom(object):
         )
 
         if exit_code != 0:
-            RuntimeError("Cannot set colorspace {} on project {}".format(
+            print("Cannot set colorspace {} on project {}".format(
                 color_policy, project_name
             ))
 

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -2,7 +2,6 @@ import os
 import json
 import tempfile
 import contextlib
-import socket
 from pprint import pformat
 
 from ayon_core.lib import (
@@ -73,8 +72,6 @@ class FlamePrelaunch(PreLaunchHook):
         user_name = get_ayon_username()
         user_name = user_name.replace(".", "_")
 
-        hostname = socket.gethostname()  # not returning wiretap host name
-
         self.log.debug("Collected user \"{}\"".format(user_name))
         self.log.info(pformat(project_entity))
         project_attribs = project_entity["attrib"]
@@ -86,7 +83,7 @@ class FlamePrelaunch(PreLaunchHook):
             "Name": project_entity["name"],
             "Nickname": project_entity["code"],
             "Description": "Created by AYON",
-            "SetupDir": project_entity["name"],
+            "SetupDir": project_entity["name"],  # Flame < 2026
             "FrameWidth": int(width),
             "FrameHeight": int(height),
             "AspectRatio": float(
@@ -97,7 +94,7 @@ class FlamePrelaunch(PreLaunchHook):
 
         data_to_script = {
             # from settings
-            "host_name": _env.get("FLAME_WIRETAP_HOSTNAME") or hostname,
+            "host_name": _env.get("FLAME_WIRETAP_HOSTNAME"),
             "volume_name": volume_name,
             "group_name": _env.get("FLAME_WIRETAP_GROUP"),
 

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -117,6 +117,15 @@ class FlamePrelaunch(PreLaunchHook):
             data_to_script["color_policy"] = str(
                 imageio_flame["project"]["colourPolicy"])
 
+        # flame 2026 replaced the colour policy by an OCIO config
+        ocio_config_path = _env.get("OCIO")
+        if ocio_config_path:
+            data_to_script["ocio_config_path"] = ocio_config_path
+        else:
+            self.log.info(
+                "'OCIO' is not set, flame keeps its default config."
+                )
+
         self.log.info(pformat(dict(_env)))
         self.log.info(pformat(data_to_script))
 
@@ -207,7 +216,8 @@ class FlamePrelaunch(PreLaunchHook):
                 "env": env
             }
 
-            run_subprocess(args, **process_kwargs)
+            output = run_subprocess(args, **process_kwargs)
+            self.log.info("wiretap_com.py output:\n{}".format(output))
 
             # process returned json file to pass launch args
             return_json_data = open(tmp_json_path).read()

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -200,7 +200,7 @@ class FlamePrelaunch(PreLaunchHook):
                 self.wtc_script_path,
                 tmp_json_path
             ]
-            self.log.info("Executing: {}".format(" ".join(args)))
+            self.log.info("Executing: %s", " ".join(args))
 
             process_kwargs = {
                 "logger": self.log,
@@ -208,13 +208,13 @@ class FlamePrelaunch(PreLaunchHook):
             }
 
             output = run_subprocess(args, **process_kwargs)
-            self.log.info("wiretap_com.py output:\n{}".format(output))
+            self.log.debug("wiretap_com.py output:\n %r", output)
 
             # process returned json file to pass launch args
             return_json_data = open(tmp_json_path).read()
             returned_data = json.loads(return_json_data)
             app_args = returned_data.get("app_args")
-            self.log.info("____ app_args: `{}`".format(app_args))
+            self.log.info("____ app_args: `%r`", app_args)
 
             if not app_args:
                 RuntimeError("App arguments were not solved")

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -117,15 +117,6 @@ class FlamePrelaunch(PreLaunchHook):
             data_to_script["color_policy"] = str(
                 imageio_flame["project"]["colourPolicy"])
 
-        # flame 2026 replaced the colour policy by an OCIO config
-        ocio_config_path = _env.get("OCIO")
-        if ocio_config_path:
-            data_to_script["ocio_config_path"] = ocio_config_path
-        else:
-            self.log.info(
-                "'OCIO' is not set, flame keeps its default config."
-                )
-
         self.log.info(pformat(dict(_env)))
         self.log.info(pformat(data_to_script))
 

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -59,6 +59,10 @@ class ImageIOProjectModel(BaseSettingsModel):
     colourPolicy: str = SettingsField(
         "ACES 1.1",
         title="Colour Policy (name or path)",
+        description=(
+            "Only used by Flame 2025 and older. Flame 2026 replaced SynColor "
+            "policies with OCIO."
+        ),
         section="Project"
     )
     frameDepth: str = SettingsField(

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -59,10 +59,6 @@ class ImageIOProjectModel(BaseSettingsModel):
     colourPolicy: str = SettingsField(
         "ACES 1.1",
         title="Colour Policy (name or path)",
-        description=(
-            "Only used by Flame 2025 and older. Flame 2026 replaced SynColor "
-            "policies with OCIO."
-        ),
         section="Project"
     )
     frameDepth: str = SettingsField(


### PR DESCRIPTION
## Changelog Description

Changes:
* [x] Report project creation fix for Flame >= 2026.1 (thanks @miravassor for [initial PR](https://github.com/ynput/ayon-flame/pull/145))
* [x] Handle special project creation API for Flame 2026.0
* [x] Validate WireTap server connection + host_name with ping
* [x] Remove hidden default value to `socket.gethostname()` in pre-hook to remain localhost

## Additional review information
Tested:
* [x] Flame 2025
* [x] Flame 2026.0
* [x] Flame 2026.1
* [x] Flame 2026.2.3
* [x] Flame 2027    

## Testing notes:
1. Open vanilla Flame out of AYON, delete any project coming from AYON
2a. Launch Flame through AYON and ensure that a valid Flame project matching AYON one get properly created
2b.Mess-up with invalid hostname (or volumes in Flame 2025) and ensure a meaningful issue is reported by AYON launcher