### PR TITLE
Implement OCIO support from Flame 2026

### DIFF
--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -773,7 +773,7 @@ class ClipLoader(LoaderPlugin):
 
             # convert colorspace with ocio to syncolor mapping from presets
             # Flame < 2026 only, already OCIO otherwise.
-            if flame.get_version_major() < 2026:
+            if int(flame.get_version_major()) < 2026:
                 colorspace = self.get_native_colorspace(colorspace)
 
             # prepare clip data from context ad send it to openClipLoader

--- a/client/ayon_flame/api/plugin.py
+++ b/client/ayon_flame/api/plugin.py
@@ -771,9 +771,10 @@ class ClipLoader(LoaderPlugin):
                     "output", "representation"
                 )
 
-            # convert colorspace with ocio to flame mapping
-            # in imageio flame section
-            colorspace = self.get_native_colorspace(colorspace)
+            # convert colorspace with ocio to syncolor mapping from presets
+            # Flame < 2026 only, already OCIO otherwise.
+            if flame.get_version_major() < 2026:
+                colorspace = self.get_native_colorspace(colorspace)
 
             # prepare clip data from context ad send it to openClipLoader
             path = self.filepath_from_context(version_context)

--- a/client/ayon_flame/api/scripts/wiretap_com.py
+++ b/client/ayon_flame/api/scripts/wiretap_com.py
@@ -81,14 +81,23 @@ class WireTapCom(object):
         Returns:
             list: arguments
         """
-
+        flame_major_version, _ = self._get_flame_version()
         workspace_name = kwargs.get("workspace_name")
-        color_policy = kwargs.get("color_policy")
 
         project_exists = self._project_prep(project_name)
         if not project_exists:
+            if flame_major_version < 2026:
+                self._set_project_syncolor_colorspace(
+                    project_name,
+                    sync_color_policy=kwargs.get("syncolor_policy")
+                )
+            else:
+                self._set_project_ocio_config(
+                    project_data,
+                    kwargs.get("ocio_config"),
+                    default_config=kwargs.get("default_ocio_config")
+                )
             self._set_project_settings(project_name, project_data)
-            self._set_project_colorspace(project_name, color_policy)
 
         launch_args = [
             "--start-project={}".format(project_name),
@@ -96,7 +105,7 @@ class WireTapCom(object):
         ]
 
         # user profiles have been removed in flame 2025
-        if self._get_flame_version()[0] < 2025:
+        if flame_major_version < 2025:
             user_name = self._user_prep(user_name)
             launch_args.append("--start-user={}".format(user_name))
 
@@ -491,21 +500,60 @@ class WireTapCom(object):
 
         print("Project settings successfully set.")
 
-    def _set_project_colorspace(self, project_name, color_policy):
-        """Set project's colorspace policy.
+
+    def _set_project_ocio_config(
+        self,
+        project_data,
+        ocio_config,
+        default_config=None,
+    ):
+        """Set project's OCIO config (Flame >= 2026 only).
+
+        Args:
+            project_data (dict): project data,
+            ocio_config (str or None): name of config
+            default_config (str or None): optional path to default config
+        """
+        if ocio_config:
+            if not os.path.exists(ocio_config):
+                print(
+                    "Ignored OCIO config (not found): {}".format(ocio_config)
+                )
+                return
+        elif default_config:
+            if not os.path.exists(default_config):
+                print(
+                    "Ignored default OCIO config (not found): {}".format(
+                        default_config
+                    )
+                )
+                return
+            ocio_config = default_config
+
+        if ocio_config:
+            print("Set project OCIO config: {}".format(ocio_config))
+            project_data["OCIOConfigFile"] = ocio_config
+
+
+    def _set_project_syncolor_colorspace(
+            self,
+            project_name,
+            sync_color_policy=None,
+    ):
+        """Set project's syncolor policy (Flame < 2026 only).
 
         Args:
             project_name (str): name of project
-            color_policy (str): name of policy
+            sync_color_policy (str or None): name of policy
 
         Raises:
             RuntimeError: Not able to set colorspace policy
         """
-        color_policy = color_policy or "Legacy"
+        color_policy = sync_color_policy or "Legacy"
 
         # check if the colour policy in custom dir
         if "/" in color_policy:
-            # if unlikelly full path was used make it redundant
+            # if unlikely full path was used make it redundant
             color_policy = color_policy.replace("/syncolor/policies/", "")
             # expecting input is `Shared/NameOfPolicy`
             color_policy = "/syncolor/policies/{}".format(
@@ -514,7 +562,28 @@ class WireTapCom(object):
             color_policy = "/syncolor/policies/Autodesk/{}".format(
                 color_policy)
 
-        # create arguments
+        # ensure color policy exists
+        try:
+            subprocess.run(
+                [
+                    os.path.join(
+                        self.wiretap_tools_dir,
+                        "wiretap_resolve_path"
+                    ),
+                    "-p",
+                    color_policy,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(
+                "Ignored invalid provided color policy: {}".format(
+                    color_policy
+                )
+            )
+            return
+
+        # set color policy on project
         project_colorspace_cmd = [
             os.path.join(
                 self.wiretap_tools_dir,

--- a/client/ayon_flame/hooks/pre_flame_setup.py
+++ b/client/ayon_flame/hooks/pre_flame_setup.py
@@ -111,8 +111,13 @@ class FlamePrelaunch(PreLaunchHook):
                 "FieldDominance": str(
                     imageio_flame["project"]["fieldDominance"])
             })
-            data_to_script["color_policy"] = str(
-                imageio_flame["project"]["colourPolicy"])
+            data_to_script["syncolor_policy"] = str(
+                imageio_flame["project"]["colourPolicy"]
+            )
+            data_to_script["ocio_config"] = _env.get("OCIO")
+            data_to_script["default_ocio_config"] = str(
+                imageio_flame["project"]["defaultOcioConfig"]
+            )
 
         self.log.info(pformat(dict(_env)))
         self.log.info(pformat(data_to_script))

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -6,6 +6,11 @@ from ayon_server.settings import (
 )
 
 
+_DEFAULT_FLAME_OCIO_CONFIG = (
+    "/opt/Autodesk/colour_mgmt/configs/legacy_configs/syncolor_aces1.1_config/config.ocio"
+)
+
+
 class ImageIOFileRuleModel(BaseSettingsModel):
     name: str = SettingsField("", title="Rule name")
     pattern: str = SettingsField("", title="Regex pattern")
@@ -58,8 +63,20 @@ class ProfileNamesMappingModel(BaseSettingsModel):
 class ImageIOProjectModel(BaseSettingsModel):
     colourPolicy: str = SettingsField(
         "ACES 1.1",
-        title="Colour Policy (name or path)",
-        section="Project"
+        title="SyncColor Policy (name or path)",
+        description=(
+            "Define SynColor preset to use when creating a new project "
+            "(Flame < 2026)."
+        )
+    )
+    defaultOcioConfig: str = SettingsField(
+        _DEFAULT_FLAME_OCIO_CONFIG,
+        title="OCIO default config",
+        description=(
+            "Path to a default OCIO config to use when creating a new project "
+            "(Flame >= 2026)\n"
+            "Only used if **no global OCIO environment variable is set**"
+        ),
     )
     frameDepth: str = SettingsField(
         "16-bit fp",
@@ -101,6 +118,7 @@ class FlameImageIOModel(BaseSettingsModel):
 DEFAULT_IMAGEIO_SETTINGS = {
     "project": {
         "colourPolicy": "ACES 1.1",
+        "defaultOcioConfig": _DEFAULT_FLAME_OCIO_CONFIG,
         "frameDepth": "16-bit fp",
         "fieldDominance": "PROGRESSIVE"
     },


### PR DESCRIPTION
## Changelog Description

Changes:
* [x] Allow default project OCIO config from settings
* [x] Allow Flame to gather OCIO config from global color management (thanks @miravassor for [initial PR](https://github.com/ynput/ayon-flame/pull/145))
* [x] Disable color management remap between Flame Syncolor and external OCIO for Flame >= 2026

## Additional review information
 
 Tested:
* [x] Flame 2025
* [x] Flame 2026.2.3
* [x] Flame 2027
 
## Testing notes:
1. Bundle and upload package
2. Remove existing AYON-generated project from Flame
3. Ensure created project color mamangement follow Flame settings
