### PR TITLE
Warn about inconsistent "Write File" node attributes instead of failing.

### DIFF
--- a/client/ayon_flame/plugins/create/create_batch_render.py
+++ b/client/ayon_flame/plugins/create/create_batch_render.py
@@ -81,11 +81,13 @@ current batch group.
             if value not in (None, ""):
                 try:
                     setattr(write_node, attr, value)
+
+                # WriteFile node attributes change based on Flame version.
                 except RuntimeError as error:
-                    raise RuntimeError(
+                    self.log.warning(
                         f"Could not set attribute '{attr}' "
-                        f"value '{value}' on Write File node."
-                    ) from error
+                        f"value '{value}' on Write File node: {error}."
+                    )
 
     def get_pre_create_attr_defs(self) -> List[BoolDef]:
         return [


### PR DESCRIPTION
## Changelog Description

The "Write File" node has changed in Flame 2026 and 2027.
It does not necessarily support all of the attributes we provide from settings, so log any issue as warning instead of existing RuntimeError.

## Testing notes:
1. Ensure a BatchRender instance can be created in Flame 2027